### PR TITLE
feat: cache TMDB API responses in database

### DIFF
--- a/src/lib/imdb/tmdb.ts
+++ b/src/lib/imdb/tmdb.ts
@@ -32,8 +32,8 @@ function getCacheKey(imdbId: string, titleHint?: string): string {
 }
 
 function getSupabaseClient() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) return null;
   return createClient(url, key);
 }

--- a/supabase/migrations/20260303030000_tmdb_data.sql
+++ b/supabase/migrations/20260303030000_tmdb_data.sql
@@ -24,7 +24,10 @@ ALTER TABLE tmdb_data ENABLE ROW LEVEL SECURITY;
 
 -- Public read/write (no user-scoping needed, this is shared cache)
 CREATE POLICY "tmdb_data_public_read" ON tmdb_data FOR SELECT USING (true);
-CREATE POLICY "tmdb_data_service_write" ON tmdb_data FOR ALL USING (true);
+CREATE POLICY "tmdb_data_service_write" ON tmdb_data
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
 
 COMMENT ON TABLE tmdb_data IS 'Cache for TMDB API responses to reduce API calls. Entries keyed by IMDB ID or title hash.';
 COMMENT ON COLUMN tmdb_data.lookup_key IS 'IMDB ID (e.g. tt1234567) or sha256 of cleaned title for non-IMDB lookups';


### PR DESCRIPTION
## Summary

Caches TMDB API responses in a new `tmdb_cache` Supabase table to avoid repeated API calls for the same content. Every /dht/ and /torrents/ detail page was making 2-3 TMDB API calls on every load.

### How it works

1. `fetchTmdbData()` checks `tmdb_cache` table first
2. If cached entry exists and is <30 days old → return cached data (0 API calls)
3. If no cache hit → call TMDB API as before → store result in cache
4. Even misses are cached (prevents repeated lookups for non-existent content)

### Cache key strategy
- **IMDB ID** (e.g. `tt1234567`) when available
- **SHA256 of cleaned title** for title-only lookups (no IMDB match)

### Migration
`supabase/migrations/20260303030000_tmdb_cache.sql` — already applied to production.

### Impact
- First visit: same as before (2-3 TMDB calls)
- Repeat visits: **0 TMDB API calls** (cache hit)
- Cache TTL: 30 days
- Non-blocking cache writes (failures don't break page)

### Testing
- Build ✅
- All 2836 tests pass ✅
- Migration applied to production ✅