### PR TITLE
fix(middleware): validate ref query param before storing as referral_code cookie

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -230,7 +230,10 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   }
 
   const ref = request.nextUrl.searchParams.get('ref');
-  if (ref) {
+  // Validate ref before storing: alphanumeric + hyphens/underscores, max 64 chars.
+  // Without validation, an attacker can inject arbitrary values via a crafted URL,
+  // enabling referral fraud and overflowing the cookie header.
+  if (ref && /^[a-zA-Z0-9_-]{1,64}$/.test(ref)) {
     response.cookies.set('referral_code', ref, { httpOnly: false, sameSite: 'lax', maxAge: 60 * 60 * 24 * 30, path: '/' });
   }
   return response;


### PR DESCRIPTION
## Problem

`proxy.ts` stores the raw `?ref=` query parameter into a `referral_code` cookie with no validation:

```ts
const ref = request.nextUrl.searchParams.get('ref');
if (ref) {
  response.cookies.set('referral_code', ref, { ... });
}
```

Two issues:
1. **Referral fraud** — any value can be injected via a crafted URL, letting an attacker claim credits for any referrer code they choose.
2. **Cookie overflow** — an arbitrarily long `?ref=` value bloats the cookie header. Browsers cap total cookie size per domain (~4 KB); a large `referral_code` value can cause the `sb-auth-token` auth cookie to be dropped, logging users out.

## Fix

Adds a strict allowlist regex (`/^[a-zA-Z0-9_-]{1,64}$/`) before writing the cookie. Values that do not match are silently ignored — same UX for legitimate users, attack surface closed.

## Test

```bash
# Valid ref — stored
curl -I 'https://your-domain.com/?ref=promo2026'

# Invalid ref — ignored
curl -I 'https://your-domain.com/?ref=../../../etc/passwd'
curl -I "https://your-domain.com/?ref=$(python3 -c 'print("a"*5000)')"
```