### PR TITLE
fix: rename proxy.ts to middleware.ts for Next.js auto-discovery

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -96,7 +96,7 @@ function getClientIp(request: NextRequest): string {
   );
 }
 
-export async function proxy(request: NextRequest): Promise<NextResponse> {
+export default async function middleware(request: NextRequest): Promise<NextResponse> {
   // Log real client IP for API requests
   const path = request.nextUrl.pathname;
   if (path.startsWith("/api/")) {


### PR DESCRIPTION
Next.js only auto-loads middleware.ts. proxy.ts was never loaded.