### PR TITLE
fix(build): webpack production build + move non-handler route exports (unblocks deploy)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint src",
     "test": "vitest run",

--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -15,21 +15,9 @@ const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 50;
 const MIN_LIMIT = 1;
 
-// Supported categories from TheNewsAPI
-export const NEWS_CATEGORIES = [
-  'general',
-  'science',
-  'sports',
-  'business',
-  'health',
-  'entertainment',
-  'tech',
-  'politics',
-  'food',
-  'travel',
-] as const;
-
-export type NewsCategory = typeof NEWS_CATEGORIES[number];
+// Re-exported from a shared module: route files may only export Route handlers
+// (the webpack production build rejects extra exports like NEWS_CATEGORIES).
+import { NEWS_CATEGORIES, type NewsCategory } from '@/lib/news/categories';
 
 interface TheNewsApiArticle {
   uuid: string;

--- a/src/app/api/youtube/auth/callback/route.ts
+++ b/src/app/api/youtube/auth/callback/route.ts
@@ -17,7 +17,7 @@ import {
   upsertAccount,
 } from '@/lib/youtube';
 import { getUserIdFromRequest } from '@/lib/youtube/request-auth';
-import { YOUTUBE_OAUTH_STATE_COOKIE } from '../start/route';
+import { YOUTUBE_OAUTH_STATE_COOKIE } from '@/lib/youtube';
 
 function redirectWithError(origin: string, message: string): NextResponse {
   const url = new URL('/youtube/accounts', origin);

--- a/src/app/api/youtube/auth/start/route.ts
+++ b/src/app/api/youtube/auth/start/route.ts
@@ -10,9 +10,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { requireActiveSubscription } from '@/lib/subscription/guard';
-import { buildAuthUrl, generateState, getGoogleOAuthConfig } from '@/lib/youtube';
-
-export const YOUTUBE_OAUTH_STATE_COOKIE = 'yt_oauth_state';
+import { buildAuthUrl, generateState, getGoogleOAuthConfig, YOUTUBE_OAUTH_STATE_COOKIE } from '@/lib/youtube';
 
 export async function GET(request: NextRequest): Promise<Response> {
   const guard = await requireActiveSubscription(request);

--- a/src/lib/news/categories.ts
+++ b/src/lib/news/categories.ts
@@ -1,0 +1,23 @@
+/**
+ * News categories — shared between the news API route and UI.
+ *
+ * Lives here (not in the route file) because Next.js route modules may only
+ * export Route handlers / config; a non-handler export like this fails the
+ * webpack production build's route type validation.
+ */
+
+// Supported categories from TheNewsAPI
+export const NEWS_CATEGORIES = [
+  'general',
+  'science',
+  'sports',
+  'business',
+  'health',
+  'entertainment',
+  'tech',
+  'politics',
+  'food',
+  'travel',
+] as const;
+
+export type NewsCategory = (typeof NEWS_CATEGORIES)[number];

--- a/src/lib/youtube/config.ts
+++ b/src/lib/youtube/config.ts
@@ -56,3 +56,6 @@ export function getGoogleOAuthConfig(): GoogleOAuthConfig {
 
   return { clientId, clientSecret, redirectUri };
 }
+
+/** Cookie name holding the OAuth state nonce during the YouTube connect flow. */
+export const YOUTUBE_OAUTH_STATE_COOKIE = 'yt_oauth_state';


### PR DESCRIPTION
Unblocks the droplet deploy, broken for a week (last success 2026-06-09), **unrelated to finance**.

- The Turbopack production build crashes finalizing standalone output (`ENOENT .next/server/middleware.js.nft.json`).
- Switch `next build` → `--webpack`, which builds cleanly **and** emits `.next/standalone/server.js`.
- Webpack enforces that route modules export only handlers/config; two routes exported a non-handler `const` and failed the build:
  - `api/news/route.ts` `NEWS_CATEGORIES` → moved to `lib/news/categories.ts`
  - `api/youtube/auth/start/route.ts` `YOUTUBE_OAUTH_STATE_COOKIE` → moved to `lib/youtube/config.ts`

Verified: clean `next build --webpack` compiles all routes (incl. `/finance`), 0 errors, standalone server.js produced; touched-area tests green (85).

🤖 Generated with [Claude Code](https://claude.com/claude-code)