### PR TITLE
fix: restore Turbopack, fix broken logo + AI Analyze 400

### DIFF
--- a/.github/workflows/deploy-droplet.yml
+++ b/.github/workflows/deploy-droplet.yml
@@ -158,9 +158,10 @@ jobs:
             echo "✓ Build complete"
             
             echo ""
-            # Verify build output exists before restarting
-            if [ ! -f .next/standalone/server.js ]; then
-              echo "✗ Build output missing (.next/standalone/server.js not found)"
+            # Verify build output exists before restarting.
+            # Runtime is `next start` (not standalone), so check for .next/BUILD_ID.
+            if [ ! -f .next/BUILD_ID ]; then
+              echo "✗ Build output missing (.next/BUILD_ID not found)"
               echo "failed" > "$STATUS_FILE"
               exit 1
             fi

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,10 +4,13 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   poweredByHeader: false,
   transpilePackages: ['@profullstack/referrals'],
-  
-  // Enable standalone output for Docker deployment
-  output: 'standalone',
-  
+
+  // NOTE: `output: 'standalone'` is intentionally NOT set.
+  // The droplet runs the app via `next start` (see scripts/setup-server.sh,
+  // ExecStart=pnpm start), which serves /public and /_next/static natively — it
+  // never uses the standalone server.js. Enabling standalone also crashes the
+  // Turbopack production build (Next 16.2.x: `ENOENT middleware.js.nft.json`).
+
   // Enable experimental features for better performance
   experimental: {
     // Enable server actions

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build --webpack",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint src",
     "test": "vitest run",

--- a/src/app/sw.js/route.ts
+++ b/src/app/sw.js/route.ts
@@ -1,39 +1,19 @@
 /**
  * Service Worker Route
  *
- * Serves the service worker file with correct headers.
- * Needed because Next.js standalone mode doesn't serve /public files directly.
+ * Serves the push-notification service worker with correct headers.
+ *
+ * The worker is inlined as a string on purpose: doing `fs.readFileSync` /
+ * `path.join(process.cwd(), …)` here makes Turbopack trace the entire project
+ * for the standalone output ("Encountered unexpected file in NFT list"), which
+ * corrupts the trace and breaks the standalone build (missing
+ * `middleware.js.nft.json`). There is no `public/sw.js` on disk anyway, so the
+ * old filesystem lookup always fell back to this inline copy.
  */
 
 import { NextResponse } from 'next/server';
-import fs from 'fs';
-import path from 'path';
 
-export async function GET(): Promise<NextResponse> {
-  try {
-    // Try multiple paths since the location differs between dev and production
-    const possiblePaths = [
-      path.join(process.cwd(), 'public', 'sw.js'),
-      path.join(process.cwd(), '..', 'public', 'sw.js'),
-      '/app/public/sw.js', // Docker path
-    ];
-
-    let swContent: string | null = null;
-
-    for (const swPath of possiblePaths) {
-      try {
-        if (fs.existsSync(swPath)) {
-          swContent = fs.readFileSync(swPath, 'utf-8');
-          break;
-        }
-      } catch {
-        // Continue to next path
-      }
-    }
-
-    if (!swContent) {
-      // Fallback: inline the service worker code
-      swContent = `
+const SERVICE_WORKER = `
 /**
  * Service Worker for Push Notifications
  */
@@ -108,17 +88,13 @@ self.addEventListener('activate', (event) => {
   event.waitUntil(clients.claim());
 });
 `;
-    }
 
-    return new NextResponse(swContent, {
-      headers: {
-        'Content-Type': 'application/javascript',
-        'Service-Worker-Allowed': '/',
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-      },
-    });
-  } catch (error) {
-    console.error('[SW Route] Error serving service worker:', error);
-    return new NextResponse('Service worker not available', { status: 500 });
-  }
+export async function GET(): Promise<NextResponse> {
+  return new NextResponse(SERVICE_WORKER, {
+    headers: {
+      'Content-Type': 'application/javascript',
+      'Service-Worker-Allowed': '/',
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+    },
+  });
 }

--- a/src/lib/finance/analysis/pipeline.ts
+++ b/src/lib/finance/analysis/pipeline.ts
@@ -47,7 +47,8 @@ export function createOpenAIReportLLM(apiKey: string): ReportLLM {
           ],
           response_format: { type: 'json_object' },
           max_completion_tokens: maxTokens,
-          temperature: 0.4,
+          // NB: gpt-5.x reasoning models only support the default temperature (1);
+          // passing a custom value returns a 400. So we omit it.
         },
         { timeout: 90_000 },
       );


### PR DESCRIPTION
Reverts the webpack switch and fixes both prod regressions.

**Root cause:** `output: 'standalone'`. The droplet runs `next start` (setup-server.sh `ExecStart=pnpm start`), so the standalone server.js is never used — but it (a) crashed the Turbopack build (Next 16.2.x `ENOENT middleware.js.nft.json`) and (b) made `/logo.svg`/`/favicon.svg` 404 (standalone doesn't bundle `/public`). Removing it lets Turbopack build cleanly and `next start` serve static assets (verified logo 200 locally).

- next.config: drop `output: 'standalone'`
- package.json: `build` back to `next build` (Turbopack), next pinned 16.2.4
- deploy check: `.next/standalone/server.js` → `.next/BUILD_ID`
- sw.js/route.ts: remove dead `fs`/`path` lookup (no `public/sw.js`; corrupted the trace)
- finance pipeline: remove `temperature: 0.4` → gpt-5.x rejects non-default temperature (Analyze 400). Verified a real report generates.

Turbopack build exit 0, all finance routes built, typecheck clean, 119 touched-area tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)