### PR TITLE
fix(deploy): service ExecStart via login shell (mise pnpm/node) + daemon-reload

### DIFF
--- a/.github/workflows/deploy-droplet.yml
+++ b/.github/workflows/deploy-droplet.yml
@@ -166,6 +166,8 @@ jobs:
               exit 1
             fi
             echo "=== Restarting services ==="
+            # Pick up any unit-file changes (e.g. ExecStart) before restarting.
+            sudo systemctl daemon-reload || true
             sudo systemctl restart bittorrented || echo "Warning: Could not restart main service"
             echo "✓ Main service restart attempted"
 

--- a/scripts/setup-server.sh
+++ b/scripts/setup-server.sh
@@ -812,11 +812,14 @@ After=network.target
 Type=simple
 User=${VPS_USER}
 WorkingDirectory=${DEPLOY_PATH}
-ExecStart=${PNPM_HOME}/pnpm start
+# Run via a login shell so pnpm AND node resolve from the user's environment
+# (mise/nvm-managed). A hardcoded \${PNPM_HOME}/pnpm path breaks when pnpm/node
+# move (e.g. to mise), which systemd reports as "failed because of unavailable
+# resources or another system error".
+ExecStart=/bin/bash -lc 'exec pnpm start'
 Restart=on-failure
 RestartSec=10
 Environment=NODE_ENV=production
-Environment=PATH=${PNPM_HOME}:/usr/local/bin:/usr/bin:/bin
 
 # Log to files instead of journald
 StandardOutput=append:${LOG_FILE}


### PR DESCRIPTION
Restores the site: the systemd unit's hardcoded `${PNPM_HOME}/pnpm` path no longer exists (pnpm/node moved to mise), so `systemctl restart` failed with 'unavailable resources' and the service went down on deploy. Run via `/bin/bash -lc 'exec pnpm start'` (inherits mise env) + add daemon-reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)