### PR TITLE
ci: install ffmpeg in test workflow (fix red 'test' check)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,12 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      # Some tests exercise the real transcoding pipeline (spawn('ffmpeg')); a
+      # missing binary throws an uncaught spawn ENOENT that fails the whole run.
+      # ci.yml's test job already installs ffmpeg — keep this workflow in sync.
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm test


### PR DESCRIPTION
test.yml lacked ffmpeg (ci.yml already has it), so transcoding tests crashed with spawn ENOENT. Adds the install step.