### PR TITLE
feat(finance): watchlist 1/5/30-day % changes, ticker news + company info

### DIFF
--- a/src/app/api/finance/asset/route.ts
+++ b/src/app/api/finance/asset/route.ts
@@ -1,0 +1,50 @@
+/**
+ * GET /api/finance/asset?symbol=NVDA
+ *
+ * Company / asset metadata for the ticker page (name, exchange, class, and the
+ * Alpaca tradability flags). Paid-gated; resolves the per-profile provider
+ * (connected Alpaca → app default) and read-through caches the result.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireActiveSubscription } from '@/lib/subscription/guard';
+import { getActiveProfileId } from '@/lib/profiles/profile-utils';
+import { getActiveBrokerCreds } from '@/lib/finance/brokers/service';
+import { getMarketDataProviderForProfile } from '@/lib/finance/market-data/for-profile';
+import { readThrough, QUOTE_TTL_SECONDS } from '@/lib/finance/market-data/cache';
+import { normalizeSymbol } from '@/lib/finance/market-data/stooq';
+import type { AssetInfo } from '@/lib/finance/market-data/types';
+
+export const dynamic = 'force-dynamic';
+
+const SYMBOL_RE = /^[A-Z][A-Z0-9.\-]{0,9}$/;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const gate = await requireActiveSubscription(request);
+  if (gate) return gate;
+
+  const symbol = normalizeSymbol(request.nextUrl.searchParams.get('symbol') ?? '');
+  if (!SYMBOL_RE.test(symbol)) {
+    return NextResponse.json({ error: 'invalid symbol' }, { status: 400 });
+  }
+
+  const profileId = await getActiveProfileId();
+  const provider = await getMarketDataProviderForProfile(profileId);
+  if (typeof provider.getAsset !== 'function') {
+    return NextResponse.json({ asset: null });
+  }
+
+  // Asset metadata is account-agnostic, but a connected broker's keys can serve
+  // it; vary the cache key by whether per-profile creds back the lookup.
+  const hasBroker = profileId ? Boolean(await getActiveBrokerCreds(profileId, 'alpaca')) : false;
+  const cacheKey = `asset:${provider.id}:${hasBroker ? 'broker' : 'app'}`;
+
+  try {
+    const asset = await readThrough<AssetInfo | null>(symbol, cacheKey, QUOTE_TTL_SECONDS, () =>
+      provider.getAsset!(symbol),
+    );
+    return NextResponse.json({ asset });
+  } catch {
+    return NextResponse.json({ asset: null });
+  }
+}

--- a/src/app/api/finance/watchlist/changes/route.ts
+++ b/src/app/api/finance/watchlist/changes/route.ts
@@ -1,0 +1,51 @@
+/**
+ * GET /api/finance/watchlist/changes?symbols=NVDA,AAPL,…
+ *
+ * Returns trailing 1 / 5 / 30-day percent gain/loss per symbol for the watchlist
+ * cards. Paid-gated; uses the per-profile market-data provider (connected
+ * broker → Yahoo fallback) and read-through caches each symbol's 1M candles.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireActiveSubscription } from '@/lib/subscription/guard';
+import { getActiveProfileId } from '@/lib/profiles/profile-utils';
+import { type MarketDataProvider } from '@/lib/finance/market-data';
+import { getMarketDataProviderForProfile } from '@/lib/finance/market-data/for-profile';
+import { readThrough, CANDLES_TTL_SECONDS } from '@/lib/finance/market-data/cache';
+import { parseSymbolList } from '@/lib/finance/watchlist';
+import { computeChanges, EMPTY_CHANGES, type WatchlistChanges } from '@/lib/finance/performance';
+
+export const dynamic = 'force-dynamic';
+
+const MAX_SYMBOLS = 60;
+
+async function changesFor(provider: MarketDataProvider, symbol: string): Promise<WatchlistChanges> {
+  return readThrough<WatchlistChanges>(symbol, `changes:${provider.id}`, CANDLES_TTL_SECONDS, async () => {
+    const candles = await provider.getCandles(symbol, '1M');
+    return computeChanges(candles);
+  });
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const gate = await requireActiveSubscription(request);
+  if (gate) return gate;
+
+  const { valid } = parseSymbolList(request.nextUrl.searchParams.get('symbols') ?? '');
+  if (valid.length === 0) return NextResponse.json({ changes: {} });
+
+  const profileId = await getActiveProfileId();
+  const provider = await getMarketDataProviderForProfile(profileId);
+
+  const symbols = valid.slice(0, MAX_SYMBOLS);
+  const entries = await Promise.all(
+    symbols.map(async (symbol): Promise<[string, WatchlistChanges]> => {
+      try {
+        return [symbol, await changesFor(provider, symbol)];
+      } catch {
+        return [symbol, EMPTY_CHANGES];
+      }
+    }),
+  );
+
+  return NextResponse.json({ changes: Object.fromEntries(entries) });
+}

--- a/src/app/finance/finance-hub.tsx
+++ b/src/app/finance/finance-hub.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link';
 import { normalizeSymbol } from '@/lib/finance/market-data/stooq';
 import { BrokerConnect } from './broker-connect';
 import { Sparkline } from '@/components/finance/sparkline';
+import type { WatchlistChanges } from '@/lib/finance/performance';
 
 const RECENT_KEY = 'finance:recent';
 
@@ -17,6 +18,19 @@ interface WatchlistRow {
   id: string;
   symbol: string;
   exchange: string | null;
+}
+
+function PctChange({ label, value }: { label: string; value: number | null }): React.ReactElement {
+  const known = value !== null && Number.isFinite(value);
+  const up = known && (value as number) >= 0;
+  const color = !known ? 'text-text-muted' : up ? 'text-green-400' : 'text-red-400';
+  const text = !known ? '—' : `${up ? '+' : ''}${(value as number).toFixed(2)}%`;
+  return (
+    <div className="flex flex-col items-center leading-tight">
+      <span className="text-[10px] uppercase tracking-wide text-text-muted">{label}</span>
+      <span className={`text-xs font-medium tabular-nums ${color}`}>{text}</span>
+    </div>
+  );
 }
 
 export function FinanceHub(): React.ReactElement {
@@ -28,6 +42,7 @@ export function FinanceHub(): React.ReactElement {
   const [bulkBusy, setBulkBusy] = useState(false);
   const [bulkMsg, setBulkMsg] = useState<string | null>(null);
   const [sparklines, setSparklines] = useState<Record<string, number[]>>({});
+  const [changes, setChanges] = useState<Record<string, WatchlistChanges>>({});
 
   useEffect(() => {
     try {
@@ -61,6 +76,24 @@ export function FinanceHub(): React.ReactElement {
       .then((res) => (res.ok ? res.json() : { samples: {} }))
       .then((body: { samples?: Record<string, number[]> }) => {
         if (!cancelled) setSparklines(body.samples ?? {});
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [watchlistKey]);
+
+  // Fetch trailing 1/5/30-day % changes for the watchlist symbols.
+  useEffect(() => {
+    if (!watchlistKey) {
+      setChanges({});
+      return;
+    }
+    let cancelled = false;
+    fetch(`/api/finance/watchlist/changes?symbols=${encodeURIComponent(watchlistKey)}`, { cache: 'no-store' })
+      .then((res) => (res.ok ? res.json() : { changes: {} }))
+      .then((body: { changes?: Record<string, WatchlistChanges> }) => {
+        if (!cancelled) setChanges(body.changes ?? {});
       })
       .catch(() => undefined);
     return () => {
@@ -190,6 +223,11 @@ export function FinanceHub(): React.ReactElement {
                   <Sparkline samples={sparklines[row.symbol]} width={56} />
                 </div>
                 {row.exchange ? <div className="text-xs text-text-muted">{row.exchange}</div> : null}
+                <div className="mt-3 flex items-center justify-between gap-1 border-t border-border-primary pt-2">
+                  <PctChange label="1D" value={changes[row.symbol]?.d1 ?? null} />
+                  <PctChange label="5D" value={changes[row.symbol]?.d5 ?? null} />
+                  <PctChange label="30D" value={changes[row.symbol]?.d30 ?? null} />
+                </div>
               </Link>
             ))}
           </div>

--- a/src/app/finance/ticker/[ticker]/ticker-view.tsx
+++ b/src/app/finance/ticker/[ticker]/ticker-view.tsx
@@ -12,9 +12,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import { FinanceChart } from './finance-chart';
 import { ReportPanel } from './report-panel';
+import { NewsSection } from '@/components/news';
 // Import from the SDK-free `types` module (not the index) so the Alpaca SDK is
 // never pulled into the client bundle.
-import { TICKER_RANGES, type Candle, type Quote, type TickerRange } from '@/lib/finance/market-data/types';
+import { TICKER_RANGES, type AssetInfo, type Candle, type Quote, type TickerRange } from '@/lib/finance/market-data/types';
+import type { WatchlistChanges } from '@/lib/finance/performance';
 
 const RECENT_KEY = 'finance:recent';
 const RECENT_MAX = 12;
@@ -58,6 +60,8 @@ export function TickerView({ symbol }: { symbol: string }): React.ReactElement {
   const [error, setError] = useState<string | null>(null);
   const [inWatchlist, setInWatchlist] = useState<boolean | null>(null);
   const [holding, setHolding] = useState<Holding | null>(null);
+  const [changes, setChanges] = useState<WatchlistChanges | null>(null);
+  const [asset, setAsset] = useState<AssetInfo | null>(null);
 
   useEffect(() => {
     rememberRecent(symbol);
@@ -132,6 +136,36 @@ export function TickerView({ symbol }: { symbol: string }): React.ReactElement {
     };
   }, [symbol]);
 
+  // Trailing 1/5/30-day % change (reuses the watchlist changes endpoint).
+  useEffect(() => {
+    let cancelled = false;
+    setChanges(null);
+    fetch(`/api/finance/watchlist/changes?symbols=${encodeURIComponent(symbol)}`, { cache: 'no-store' })
+      .then((res) => (res.ok ? res.json() : { changes: {} }))
+      .then((body: { changes?: Record<string, WatchlistChanges> }) => {
+        if (!cancelled) setChanges(body.changes?.[symbol] ?? null);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [symbol]);
+
+  // Company / asset metadata (Alpaca assets endpoint).
+  useEffect(() => {
+    let cancelled = false;
+    setAsset(null);
+    fetch(`/api/finance/asset?symbol=${encodeURIComponent(symbol)}`, { cache: 'no-store' })
+      .then((res) => (res.ok ? res.json() : { asset: null }))
+      .then((body: { asset?: AssetInfo | null }) => {
+        if (!cancelled) setAsset(body.asset ?? null);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [symbol]);
+
   const toggleWatchlist = useCallback(async () => {
     const next = !inWatchlist;
     setInWatchlist(next);
@@ -167,6 +201,12 @@ export function TickerView({ symbol }: { symbol: string }): React.ReactElement {
               {inWatchlist ? '★ In watchlist' : '☆ Add to watchlist'}
             </button>
           </div>
+          {asset?.name ? (
+            <div className="mt-1 text-sm text-text-secondary">
+              {asset.name}
+              {asset.exchange ? <span className="text-text-muted"> · {asset.exchange}</span> : null}
+            </div>
+          ) : null}
           {quote ? <div className="mt-2 flex items-baseline gap-3">
               <span className="text-2xl font-semibold text-text-primary">
                 ${formatNumber(quote.price, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
@@ -177,6 +217,11 @@ export function TickerView({ symbol }: { symbol: string }): React.ReactElement {
                 {formatNumber(quote.changePercent, { maximumFractionDigits: 2 })}%)
               </span>
             </div> : null}
+          <div className="mt-3 flex items-center gap-5">
+            <TrailingChange label="1D" value={changes?.d1 ?? null} />
+            <TrailingChange label="5D" value={changes?.d5 ?? null} />
+            <TrailingChange label="30D" value={changes?.d30 ?? null} />
+          </div>
         </div>
         <div className="flex flex-wrap gap-1">
           {TICKER_RANGES.map((r) => (
@@ -223,8 +268,35 @@ export function TickerView({ symbol }: { symbol: string }): React.ReactElement {
         />
       </div>
 
+      {/* Company info from the broker (Alpaca) assets endpoint. */}
+      {asset ? (
+        <section className="mt-8">
+          <h2 className="mb-3 text-lg font-semibold text-text-primary">About {symbol}</h2>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {asset.name ? <Stat label="Name" value={asset.name} /> : null}
+            {asset.exchange ? <Stat label="Exchange" value={asset.exchange} /> : null}
+            {asset.assetClass ? <Stat label="Class" value={formatAssetClass(asset.assetClass)} /> : null}
+            {asset.status ? <Stat label="Status" value={capitalize(asset.status)} /> : null}
+            <Stat label="Tradable" value={formatBool(asset.tradable)} />
+            <Stat label="Fractionable" value={formatBool(asset.fractionable)} />
+            <Stat label="Marginable" value={formatBool(asset.marginable)} />
+            <Stat label="Shortable" value={formatBool(asset.shortable)} />
+            <Stat label="Easy to borrow" value={formatBool(asset.easyToBorrow)} />
+            {asset.hasOptions !== null ? <Stat label="Options" value={formatBool(asset.hasOptions)} /> : null}
+          </div>
+        </section>
+      ) : null}
+
       {/* AI report area — never auto-runs; the Analyze button is the cost boundary. */}
       <ReportPanel symbol={symbol} />
+
+      {/* Ticker news — pulls from our /news API, searched by symbol. */}
+      <section className="mt-8">
+        <h2 className="mb-3 text-lg font-semibold text-text-primary">
+          News for {symbol}
+        </h2>
+        <NewsSection searchTerm={symbol} limit={10} />
+      </section>
     </div>
   );
 }
@@ -236,4 +308,33 @@ function Stat({ label, value }: { label: string; value: string }): React.ReactEl
       <div className="mt-1 text-base font-semibold text-text-primary">{value}</div>
     </div>
   );
+}
+
+function TrailingChange({ label, value }: { label: string; value: number | null }): React.ReactElement {
+  const known = value !== null && Number.isFinite(value);
+  const up = known && (value as number) >= 0;
+  const color = !known ? 'text-text-muted' : up ? 'text-green-400' : 'text-red-400';
+  const text = !known ? '—' : `${up ? '+' : ''}${(value as number).toFixed(2)}%`;
+  return (
+    <div className="flex items-baseline gap-1.5">
+      <span className="text-xs uppercase tracking-wider text-text-muted">{label}</span>
+      <span className={`text-sm font-semibold tabular-nums ${color}`}>{text}</span>
+    </div>
+  );
+}
+
+function formatBool(value: boolean | null): string {
+  if (value === null) return '—';
+  return value ? 'Yes' : 'No';
+}
+
+function capitalize(value: string): string {
+  return value ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+}
+
+function formatAssetClass(value: string): string {
+  return value
+    .split('_')
+    .map((part) => (part === 'us' ? 'US' : capitalize(part)))
+    .join(' ');
 }

--- a/src/lib/finance/market-data/alpaca.test.ts
+++ b/src/lib/finance/market-data/alpaca.test.ts
@@ -65,4 +65,51 @@ describe('AlpacaMarketDataProvider', () => {
     const p = new AlpacaMarketDataProvider({ clientFactory: () => makeClient(BARS) });
     expect(await p.search()).toEqual([]);
   });
+
+  it('maps asset metadata from getAsset', async () => {
+    const client: AlpacaDataClient = {
+      ...makeClient(BARS),
+      getAsset: async (symbol: string) => ({
+        symbol,
+        name: 'NVIDIA Corporation',
+        exchange: 'NASDAQ',
+        class: 'us_equity',
+        status: 'active',
+        tradable: true,
+        marginable: true,
+        shortable: true,
+        easy_to_borrow: true,
+        fractionable: true,
+        attributes: ['options_enabled'],
+      }),
+    };
+    const p = new AlpacaMarketDataProvider({ clientFactory: () => client });
+    const asset = await p.getAsset('nvda');
+    expect(asset).toMatchObject({
+      symbol: 'NVDA',
+      name: 'NVIDIA Corporation',
+      exchange: 'NASDAQ',
+      assetClass: 'us_equity',
+      status: 'active',
+      tradable: true,
+      fractionable: true,
+      hasOptions: true,
+    });
+  });
+
+  it('returns null asset when the SDK lacks getAsset', async () => {
+    const p = new AlpacaMarketDataProvider({ clientFactory: () => makeClient(BARS) });
+    expect(await p.getAsset('nvda')).toBeNull();
+  });
+
+  it('returns null asset when getAsset throws', async () => {
+    const client: AlpacaDataClient = {
+      ...makeClient(BARS),
+      getAsset: async () => {
+        throw new Error('not found');
+      },
+    };
+    const p = new AlpacaMarketDataProvider({ clientFactory: () => client });
+    expect(await p.getAsset('zzzz')).toBeNull();
+  });
 });

--- a/src/lib/finance/market-data/alpaca.ts
+++ b/src/lib/finance/market-data/alpaca.ts
@@ -10,6 +10,7 @@
 
 import Alpaca from '@alpacahq/alpaca-trade-api';
 import {
+  type AssetInfo,
   type Candle,
   type MarketDataProvider,
   type Quote,
@@ -28,12 +29,29 @@ interface AlpacaBarRaw {
   Volume?: number;
 }
 
+/** Raw shape returned by Alpaca's `GET /v2/assets/{symbol}`. */
+export interface AlpacaAssetRaw {
+  symbol?: string;
+  name?: string;
+  exchange?: string;
+  class?: string;
+  status?: string;
+  tradable?: boolean;
+  marginable?: boolean;
+  shortable?: boolean;
+  easy_to_borrow?: boolean;
+  fractionable?: boolean;
+  attributes?: string[];
+}
+
 /** Narrow slice of the SDK we use for market data. */
 export interface AlpacaDataClient {
   getBarsV2(symbol: string, options: Record<string, unknown>): AsyncIterable<AlpacaBarRaw>;
   newTimeframe(amount: number, unit: string): string;
   // SDK enum keys are uppercase: MIN="Min", HOUR="Hour", DAY="Day".
   timeframeUnit: { MIN: string; HOUR: string; DAY: string };
+  /** Trading API: asset metadata. Present on the full SDK client. */
+  getAsset?(symbol: string): Promise<AlpacaAssetRaw>;
 }
 
 export type AlpacaDataClientFactory = () => AlpacaDataClient;
@@ -115,5 +133,32 @@ export class AlpacaMarketDataProvider implements MarketDataProvider {
   /** Alpaca has no fuzzy search; Finnhub handles typeahead. */
   async search(): Promise<SymbolSearchResult[]> {
     return [];
+  }
+
+  /** Company/asset metadata from Alpaca's assets endpoint. */
+  async getAsset(symbol: string): Promise<AssetInfo | null> {
+    const client = this.factory();
+    if (typeof client.getAsset !== 'function') return null;
+    const canonical = normalizeSymbol(symbol);
+    try {
+      const a = await client.getAsset(canonical);
+      if (!a) return null;
+      const attrs = Array.isArray(a.attributes) ? a.attributes : [];
+      return {
+        symbol: a.symbol ?? canonical,
+        name: a.name ?? null,
+        exchange: a.exchange ?? null,
+        assetClass: a.class ?? null,
+        status: a.status ?? null,
+        tradable: a.tradable ?? null,
+        marginable: a.marginable ?? null,
+        shortable: a.shortable ?? null,
+        easyToBorrow: a.easy_to_borrow ?? null,
+        fractionable: a.fractionable ?? null,
+        hasOptions: attrs.length ? attrs.some((x) => x.includes('option')) : null,
+      };
+    } catch {
+      return null;
+    }
   }
 }

--- a/src/lib/finance/market-data/finnhub.ts
+++ b/src/lib/finance/market-data/finnhub.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  type AssetInfo,
   type Candle,
   type MarketDataProvider,
   type Quote,
@@ -68,6 +69,11 @@ export class FinnhubMarketDataProvider implements MarketDataProvider {
   /** Candles come from the delegate (Stooq EOD) — Finnhub free blocks them. */
   async getCandles(symbol: string, range: TickerRange): Promise<Candle[]> {
     return this.candleProvider.getCandles(symbol, range);
+  }
+
+  /** Asset metadata comes from the delegate (Alpaca) when it supports it. */
+  async getAsset(symbol: string): Promise<AssetInfo | null> {
+    return this.candleProvider.getAsset?.(symbol) ?? null;
   }
 
   async getQuote(symbol: string): Promise<Quote | null> {

--- a/src/lib/finance/market-data/types.ts
+++ b/src/lib/finance/market-data/types.ts
@@ -46,12 +46,36 @@ export interface SymbolSearchResult {
   exchange?: string;
 }
 
+/**
+ * Company / asset metadata for the ticker page. Sourced from the broker's
+ * assets endpoint (Alpaca). All fields are nullable — providers fill in only
+ * what they expose.
+ */
+export interface AssetInfo {
+  symbol: string;
+  name: string | null;
+  exchange: string | null;
+  /** e.g. "us_equity", "crypto". */
+  assetClass: string | null;
+  /** e.g. "active", "inactive". */
+  status: string | null;
+  tradable: boolean | null;
+  marginable: boolean | null;
+  shortable: boolean | null;
+  easyToBorrow: boolean | null;
+  fractionable: boolean | null;
+  /** Whether the asset has tradable options (from Alpaca asset attributes). */
+  hasOptions: boolean | null;
+}
+
 export interface MarketDataProvider {
   /** Stable identifier used in cache keys and logs. */
   readonly id: string;
   getCandles(symbol: string, range: TickerRange): Promise<Candle[]>;
   getQuote(symbol: string): Promise<Quote | null>;
   search(query: string): Promise<SymbolSearchResult[]>;
+  /** Company/asset metadata, when the provider exposes it (Alpaca). */
+  getAsset?(symbol: string): Promise<AssetInfo | null>;
 }
 
 /** Approximate trailing-day window for each range (daily EOD bars). */

--- a/src/lib/finance/performance.test.ts
+++ b/src/lib/finance/performance.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { computeChanges, pctChangeOverDays, EMPTY_CHANGES } from './performance';
+import type { Candle } from './market-data/types';
+
+const DAY = 86_400;
+
+/** Build a daily candle series ending "today" from a list of closes. */
+function series(closes: number[], endTime = 1_700_000_000): Candle[] {
+  const n = closes.length;
+  return closes.map((close, i) => ({
+    time: endTime - (n - 1 - i) * DAY,
+    open: close,
+    high: close,
+    low: close,
+    close,
+    volume: 0,
+  }));
+}
+
+describe('pctChangeOverDays', () => {
+  it('computes the 1-day change from the prior trading day', () => {
+    const candles = series([100, 110]); // yesterday 100 → today 110
+    expect(pctChangeOverDays(candles, 1)).toBeCloseTo(10, 5);
+  });
+
+  it('computes the 5-day change against the bar ~5 days back', () => {
+    const candles = series([100, 101, 102, 103, 104, 120]);
+    // last.time - 5d lands on the first bar (close 100): (120-100)/100 = 20%
+    expect(pctChangeOverDays(candles, 5)).toBeCloseTo(20, 5);
+  });
+
+  it('handles a 30-day window, picking the nearest prior bar', () => {
+    const closes = Array.from({ length: 31 }, (_, i) => 100 + i); // 100..130
+    const candles = series(closes);
+    // 30 days back == first bar (100): (130-100)/100 = 30%
+    expect(pctChangeOverDays(candles, 30)).toBeCloseTo(30, 5);
+  });
+
+  it('falls back to the oldest bar when history is too short', () => {
+    const candles = series([50, 75]); // only 1 day apart, asked for 30
+    expect(pctChangeOverDays(candles, 30)).toBeCloseTo(50, 5);
+  });
+
+  it('returns null for insufficient data', () => {
+    expect(pctChangeOverDays([], 1)).toBeNull();
+    expect(pctChangeOverDays(series([100]), 1)).toBeNull();
+  });
+
+  it('returns negative values for losses', () => {
+    expect(pctChangeOverDays(series([200, 150]), 1)).toBeCloseTo(-25, 5);
+  });
+});
+
+describe('computeChanges', () => {
+  it('returns all three windows', () => {
+    const closes = Array.from({ length: 31 }, (_, i) => 100 + i);
+    const changes = computeChanges(series(closes));
+    expect(changes.d1).toBeCloseTo((130 - 129) / 129 * 100, 5);
+    expect(changes.d5).toBeCloseTo((130 - 125) / 125 * 100, 5);
+    expect(changes.d30).toBeCloseTo(30, 5);
+  });
+
+  it('sorts unordered candles before computing', () => {
+    const ordered = series([100, 110]);
+    const shuffled = [ordered[1], ordered[0]];
+    expect(computeChanges(shuffled).d1).toBeCloseTo(10, 5);
+  });
+
+  it('returns empty changes for too-short input', () => {
+    expect(computeChanges([])).toEqual(EMPTY_CHANGES);
+    expect(computeChanges(series([100]))).toEqual(EMPTY_CHANGES);
+  });
+});

--- a/src/lib/finance/performance.ts
+++ b/src/lib/finance/performance.ts
@@ -1,0 +1,56 @@
+/**
+ * Finance — trailing % change helpers for the watchlist.
+ *
+ * Given a series of daily EOD candles (ascending by time), compute the percent
+ * gain/loss over the trailing 1, 5, and 30 calendar days. We look back by
+ * calendar days (not bar count) and pick the latest bar at-or-before the cutoff,
+ * so weekends/holidays/gaps resolve to the nearest prior trading day.
+ */
+
+import type { Candle } from './market-data/types';
+
+export interface WatchlistChanges {
+  /** Trailing 1-day % change (previous trading day → latest). */
+  d1: number | null;
+  /** Trailing 5-day % change. */
+  d5: number | null;
+  /** Trailing 30-day % change. */
+  d30: number | null;
+}
+
+export const EMPTY_CHANGES: WatchlistChanges = { d1: null, d5: null, d30: null };
+
+const DAY_SECONDS = 86_400;
+
+/** Percent change over `days` calendar days, or null if not derivable. */
+export function pctChangeOverDays(candles: Candle[], days: number): number | null {
+  if (candles.length < 2) return null;
+  const last = candles[candles.length - 1];
+  if (!last?.close) return null;
+
+  const cutoff = last.time - days * DAY_SECONDS;
+  let base: Candle | undefined;
+  for (let i = candles.length - 2; i >= 0; i--) {
+    if (candles[i].time <= cutoff) {
+      base = candles[i];
+      break;
+    }
+  }
+  // Not enough history to reach the full lookback: fall back to the oldest bar
+  // we have so a partial window still surfaces a (smaller) change.
+  if (!base) base = candles[0];
+  if (!base.close) return null;
+
+  return ((last.close - base.close) / base.close) * 100;
+}
+
+/** Compute trailing 1/5/30-day changes from a daily candle series. */
+export function computeChanges(candles: Candle[]): WatchlistChanges {
+  if (!candles || candles.length < 2) return EMPTY_CHANGES;
+  const sorted = [...candles].sort((a, b) => a.time - b.time);
+  return {
+    d1: pctChangeOverDays(sorted, 1),
+    d5: pctChangeOverDays(sorted, 5),
+    d30: pctChangeOverDays(sorted, 30),
+  };
+}


### PR DESCRIPTION
## Summary
Builds on the watchlist sparklines branch with performance %, ticker news, and company info.

- **Trailing % changes (1D / 5D / 30D)** on both the watchlist cards (`finance-hub`) and the ticker chart header (`ticker-view`). New pure helper `lib/finance/performance.ts` (calendar-day lookback → nearest prior trading day; falls back to oldest bar on short history) + paid-gated `/api/finance/watchlist/changes` endpoint (per-profile provider, no Yahoo fallback).
- **Ticker news** — reuses the existing `NewsSection` component to add a `/news`-backed "News for {symbol}" section on the chart page (searched by symbol).
- **Company info from Alpaca** — `AssetInfo` + optional `getAsset()` on the market-data provider interface; Alpaca implements it via the assets endpoint (name, exchange, class, status, tradability flags, options), Finnhub delegates to it. New paid-gated, cached `/api/finance/asset` route. Rendered as company name/exchange in the header + an "About {symbol}" stats grid.

## Verification
- `tsc --noEmit` clean
- Full suite: **2259 passed, 3 skipped** (pre-commit hook)
- New tests: performance helper (9), Alpaca `getAsset` mapping (success / no-method / throws)

## Notes
- Alpaca's assets API is trading metadata only (no sector / market cap / logo). Finnhub `/stock/profile2` could supply those later if richer fundamentals are wanted.
- 6 non-blocking `set-state-in-effect` lint warnings; consistent with the file's existing effect pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)