### PR TITLE
fix(payments): point premium/family webhook at the route that actually exists

### DIFF
--- a/src/app/api/payments/route.test.ts
+++ b/src/app/api/payments/route.test.ts
@@ -116,6 +116,27 @@ describe('Payment API Route', () => {
       expect(data.payment.plan).toBe('premium');
     });
 
+    it('should register the webhook at a route that actually exists (src/app/api/webhooks/coinpayportal)', async () => {
+      const { POST } = await import('./route');
+
+      const request = new Request('http://localhost:3000/api/payments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          plan: 'premium',
+          cryptoType: 'BTC',
+        }),
+      });
+
+      await POST(request);
+
+      expect(mockCreatePayment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          webhookUrl: expect.stringMatching(/\/api\/webhooks\/coinpayportal$/),
+        })
+      );
+    });
+
     it('should create a payment request for family plan', async () => {
       const { POST } = await import('./route');
       

--- a/src/app/api/payments/route.ts
+++ b/src/app/api/payments/route.ts
@@ -112,7 +112,7 @@ export async function POST(request: Request): Promise<NextResponse> {
           plan,
           userEmail: user.email,
         },
-        webhookUrl: `${baseUrl}/api/payments/webhook`,
+        webhookUrl: `${baseUrl}/api/webhooks/coinpayportal`,
         redirectUrl: `${baseUrl}/account?payment=success`,
       });
     } catch (apiError) {


### PR DESCRIPTION
Fixes #122.

`POST /api/payments` was registering the CoinPayPortal webhook at `${baseUrl}/api/payments/webhook`, which doesn't exist as a route — only `/api/webhooks/coinpayportal` does (the handler that verifies the signature and calls `activateSubscription()`). Since subscription access is gated entirely by the `user_subscriptions` table, and that table is only ever written from the webhook handler, premium/family payments confirm on CoinPayPortal's side but the app never activates the subscription.

The IPTV subscription flow doesn't have this bug — both of its payment-creation routes correctly point `webhookUrl` at `/api/iptv/subscription/webhook`, which exists. This PR makes the main payments route consistent with that.

Change:
- `src/app/api/payments/route.ts`: point `webhookUrl` at `/api/webhooks/coinpayportal`.
- `src/app/api/payments/route.test.ts`: added a regression test asserting the webhook URL passed to `createPayment()` matches the real route, so this can't silently regress again.

Couldn't run the suite locally — this sandbox doesn't have pnpm and a plain `npm install` didn't produce `node_modules` for the workspace — so I traced the new test through the existing mock setup by hand rather than executing it. Happy to adjust if CI flags anything.
