### PR TITLE
fix(comments): validate pagination params

### DIFF
--- a/src/app/api/torrents/[id]/comments/route.test.ts
+++ b/src/app/api/torrents/[id]/comments/route.test.ts
@@ -134,6 +134,25 @@ describe('Torrent Comments API', () => {
       expect(mockService.getCommentsWithUserVotes).toHaveBeenCalledWith(TEST_TORRENT_ID, null, 10, 20);
     });
 
+    it('should fall back to safe pagination for malformed params', async () => {
+      const mockService = {
+        getCommentsWithUserVotes: vi.fn().mockResolvedValue([]),
+        getCommentCount: vi.fn().mockResolvedValue(0),
+      };
+
+      (getCommentsService as ReturnType<typeof vi.fn>).mockReturnValue(mockService);
+      (getActiveProfileId as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      const request = new NextRequest(
+        `http://localhost/api/torrents/${TEST_TORRENT_ID}/comments?limit=10items&offset=-20`
+      );
+      const response = await GET(request, { params: Promise.resolve({ id: TEST_TORRENT_ID }) });
+
+      expect(response.status).toBe(200);
+      expect(mockService.getCommentsWithUserVotes).toHaveBeenCalledWith(TEST_TORRENT_ID, null, 50, 0);
+      await expect(response.json()).resolves.toMatchObject({ limit: 50, offset: 0 });
+    });
+
     it('should return 400 for missing torrent ID', async () => {
       const request = new NextRequest('http://localhost/api/torrents//comments');
       const response = await GET(request, { params: Promise.resolve({ id: '' }) });

--- a/src/app/api/torrents/[id]/comments/route.ts
+++ b/src/app/api/torrents/[id]/comments/route.ts
@@ -12,6 +12,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getCommentsService } from '@/lib/comments';
 import { getAuthenticatedUser } from '@/lib/auth';
 import { getActiveProfileId } from '@/lib/profiles/profile-utils';
+import { parseIntegerParam } from '@/lib/api/pagination';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -50,8 +51,8 @@ export async function GET(
 
     // Parse pagination params
     const searchParams = request.nextUrl.searchParams;
-    const limit = parseInt(searchParams.get('limit') ?? '50', 10);
-    const offset = parseInt(searchParams.get('offset') ?? '0', 10);
+    const limit = parseIntegerParam(searchParams.get('limit'), { min: 1, max: 100 }) ?? 50;
+    const offset = parseIntegerParam(searchParams.get('offset'), { min: 0 }) ?? 0;
 
     // DHT torrents (non-UUID IDs) don't support comments
     // Return empty results instead of failing


### PR DESCRIPTION
## Description
Validate torrent comment pagination with the repository's strict integer parser. Malformed, negative, fractional, oversized, and partial values now fall back to safe defaults instead of reaching the database query.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## TDD Checklist
- [ ] Tests written FIRST (before implementation)
- [x] All new code has corresponding tests
- [ ] All tests pass locally (`pnpm test`) — 2,335 pass; 6 unrelated Windows/stale baseline failures
- [x] Edge cases are covered
- [x] No `any` types used
- [ ] TypeScript strict mode passes — local install is blocked by the minimum-release-age policy for today's `@profullstack/stack@0.1.3`
- [x] ESLint passes

## Security Checklist
- [x] No Supabase calls from client-side code
- [x] No sensitive data exposed in client bundle
- [x] Input validation implemented
- [x] Rate limiting considered (not applicable to this read-only pagination change)

## Testing
### Test Coverage
- Number of new tests: 1
- Test file modified: `src/app/api/torrents/[id]/comments/route.test.ts`

### Results
- Focused route tests: 10/10 passed
- Full suite: 2,335 passed, 7 skipped; 6 unrelated baseline failures
- ESLint: 0 errors
- `git diff --check`: passed

## Additional Notes
The full-suite failures are unrelated to this change: Unix-only `sleep`/path assertions on Windows and a stale torlnk package expectation. No invoice will be sent until the PR is merged and accepted.