### PR TITLE
fix(seedbox): supervise torlink, add a health watchdog, and report the real connect error

### DIFF
--- a/src/app/api/account/seedbox/status/route.ts
+++ b/src/app/api/account/seedbox/status/route.ts
@@ -5,6 +5,7 @@ import { getCurrentUser } from '@/lib/auth';
 import { loadAccountSeedboxConfig } from '@/lib/seedbox';
 import { filesAuthHeaders } from '@/lib/seedbox/files';
 import { buildAuthHeaders } from '@/lib/seedbox/http-transport';
+import { describeFetchError } from '@/lib/seedbox/fetch-error';
 import { isLiveTorrent } from '@/lib/seedbox/torlink-reconcile';
 
 // Live torlink status for the account's seedbox: what's downloading, queued,
@@ -128,8 +129,11 @@ export async function GET(): Promise<NextResponse> {
       { status: 200, headers: NO_STORE }
     );
   } catch (error) {
+    // Surface the root cause: "ECONNREFUSED — the daemon is down" and
+    // "ENOTFOUND — the hostname doesn't resolve" both used to render as the
+    // indistinguishable (and unactionable) string "fetch failed".
     return NextResponse.json(
-      { configured: true, reachable: false, error: error instanceof Error ? error.message : String(error) },
+      { configured: true, reachable: false, error: describeFetchError(error) },
       { status: 200, headers: NO_STORE }
     );
   } finally {

--- a/src/app/api/account/seedbox/test/route.ts
+++ b/src/app/api/account/seedbox/test/route.ts
@@ -4,6 +4,7 @@ import { getCurrentUser } from '@/lib/auth';
 import { loadAccountSeedboxConfig } from '@/lib/seedbox';
 import { buildAuthHeaders } from '@/lib/seedbox/http-transport';
 import { filesAuthHeaders } from '@/lib/seedbox/files';
+import { describeFetchError } from '@/lib/seedbox/fetch-error';
 
 // Probe the account's seedbox end to end:
 //  - reachable: did the port answer at all? (network error/timeout => firewall
@@ -40,12 +41,12 @@ async function probe(
     const res = await fetch(url, { ...init, signal: controller.signal, cache: 'no-store' });
     return { ...classify(res.status), status: res.status };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    const isTimeout = /abort/i.test(message);
     return {
       reachable: false,
       authorized: false,
-      error: isTimeout ? 'timed out (port blocked by a firewall, or daemon down)' : message,
+      // Unwraps undici's cause chain, so "fetch failed" becomes e.g.
+      // "ECONNREFUSED — nothing is listening on that port…".
+      error: describeFetchError(error, 'timed out (port blocked by a firewall, or daemon down)'),
     };
   } finally {
     clearTimeout(timer);

--- a/src/lib/seedbox/fetch-error.test.ts
+++ b/src/lib/seedbox/fetch-error.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+
+import { describeFetchError, isAbortError, rootCauseCode } from './fetch-error';
+
+/** Build the shape undici actually throws: TypeError('fetch failed') + cause. */
+function undiciError(code: string): TypeError {
+  return new TypeError('fetch failed', { cause: Object.assign(new Error(`connect ${code}`), { code }) });
+}
+
+describe('seedbox fetch-error', () => {
+  describe('rootCauseCode', () => {
+    it('pulls the code out of undici’s cause chain', () => {
+      expect(rootCauseCode(undiciError('ECONNREFUSED'))).toBe('ECONNREFUSED');
+    });
+
+    it('walks nested causes to the deepest code', () => {
+      const deep = new Error('outer', {
+        cause: new Error('middle', { cause: Object.assign(new Error('inner'), { code: 'ENOTFOUND' }) }),
+      });
+      expect(rootCauseCode(deep)).toBe('ENOTFOUND');
+    });
+
+    it('reads codes out of an AggregateError (happy-eyeballs A/AAAA failure)', () => {
+      const agg = new AggregateError(
+        [Object.assign(new Error('v6'), { code: 'ENETUNREACH' })],
+        'all attempts failed'
+      );
+      expect(rootCauseCode(new TypeError('fetch failed', { cause: agg }))).toBe('ENETUNREACH');
+    });
+
+    it('returns null when there is no code anywhere', () => {
+      expect(rootCauseCode(new Error('plain'))).toBeNull();
+      expect(rootCauseCode('a string')).toBeNull();
+    });
+
+    it('does not loop forever on a self-referential cause', () => {
+      const loop = new Error('loop') as Error & { cause?: unknown };
+      loop.cause = loop;
+      expect(rootCauseCode(loop)).toBeNull();
+    });
+  });
+
+  describe('isAbortError', () => {
+    it('recognizes an aborted request', () => {
+      const err = new Error('This operation was aborted');
+      err.name = 'AbortError';
+      expect(isAbortError(err)).toBe(true);
+    });
+
+    it('does not treat a refused connection as an abort', () => {
+      expect(isAbortError(undiciError('ECONNREFUSED'))).toBe(false);
+    });
+  });
+
+  describe('describeFetchError', () => {
+    it('replaces the useless "fetch failed" with the code and a remedy', () => {
+      const msg = describeFetchError(undiciError('ECONNREFUSED'));
+      expect(msg).not.toBe('fetch failed');
+      expect(msg).toContain('ECONNREFUSED');
+      expect(msg).toContain('daemon is down');
+    });
+
+    it('distinguishes a dead host from a dead daemon', () => {
+      const refused = describeFetchError(undiciError('ECONNREFUSED'));
+      const dns = describeFetchError(undiciError('ENOTFOUND'));
+      expect(refused).not.toBe(dns);
+      expect(dns).toContain("doesn't resolve");
+    });
+
+    it('reports a timeout as a timeout, not as a transport error', () => {
+      const err = new Error('This operation was aborted');
+      err.name = 'AbortError';
+      expect(describeFetchError(err)).toContain('timed out');
+      expect(describeFetchError(err, 'custom timeout text')).toBe('custom timeout text');
+    });
+
+    it('keeps an informative message and appends the code', () => {
+      const err = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+      expect(describeFetchError(err)).toContain('socket hang up');
+      expect(describeFetchError(err)).toContain('ECONNRESET');
+    });
+
+    it('falls back to the raw message for an uncoded error', () => {
+      expect(describeFetchError(new Error('something odd'))).toBe('something odd');
+    });
+
+    it('surfaces an unmapped code rather than swallowing it', () => {
+      expect(describeFetchError(undiciError('ESOMETHINGNEW'))).toContain('ESOMETHINGNEW');
+    });
+  });
+});

--- a/src/lib/seedbox/fetch-error.ts
+++ b/src/lib/seedbox/fetch-error.ts
@@ -1,0 +1,104 @@
+/**
+ * Turn a failed `fetch` into a message that says what actually went wrong.
+ *
+ * Node's undici throws `TypeError: fetch failed` for every transport-level
+ * failure — refused connection, dead DNS, unreachable host, TLS mismatch — and
+ * hides the real reason in `error.cause.code`. Reporting `error.message` alone
+ * collapses all of those to the two useless words "fetch failed", which is why
+ * a down torlink daemon and a wrong seedbox hostname looked identical in the UI.
+ *
+ * `describeFetchError` walks the cause chain, pulls out the OS-level code, and
+ * pairs it with the operator action that actually fixes that case.
+ *
+ * Note that an `AbortSignal` timeout is NOT "fetch failed" — it surfaces as
+ * "This operation was aborted". That distinction matters: a refused connection
+ * means nothing is listening, whereas a timeout means packets are being dropped
+ * (a firewall). Keeping them apart is the whole point of this helper.
+ */
+
+/** Plain-English cause + remedy per OS/undici error code. */
+const CODE_HINTS: Record<string, string> = {
+  ECONNREFUSED: 'nothing is listening on that port — the torlink daemon is down or bound to a different port',
+  ENOTFOUND: "the hostname doesn't resolve — check the seedbox host in Settings",
+  EAI_AGAIN: 'DNS lookup failed — check the seedbox host in Settings',
+  EHOSTUNREACH: 'the host is unreachable — wrong IP, or the box is powered off',
+  ENETUNREACH: 'the network is unreachable from the app server',
+  ETIMEDOUT: 'the connection timed out — a firewall is dropping packets on that port',
+  UND_ERR_CONNECT_TIMEOUT: 'the connection timed out — a firewall is dropping packets on that port',
+  ECONNRESET: 'the connection was reset — the daemon may have restarted mid-request',
+  EPIPE: 'the connection closed unexpectedly',
+  EPROTO: 'protocol mismatch — is the URL http:// where the daemon speaks https:// (or vice versa)?',
+  DEPTH_ZERO_SELF_SIGNED_CERT: 'the seedbox uses a self-signed TLS certificate',
+  UNABLE_TO_VERIFY_LEAF_SIGNATURE: 'the seedbox TLS certificate could not be verified',
+  CERT_HAS_EXPIRED: 'the seedbox TLS certificate has expired',
+};
+
+/**
+ * Deepest `code` in an error's cause chain. undici nests the real socket error
+ * one or two levels down, and multi-address (A + AAAA) failures arrive as an
+ * `AggregateError` whose `.errors` hold the per-address codes.
+ */
+export function rootCauseCode(error: unknown): string | null {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  let code: string | null = null;
+
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    const candidate = (current as { code?: unknown }).code;
+    if (typeof candidate === 'string' && candidate.length > 0) code = candidate;
+
+    // AggregateError (happy-eyeballs): take the first member that carries a code.
+    const members = (current as { errors?: unknown }).errors;
+    if (Array.isArray(members)) {
+      for (const member of members) {
+        const nested = rootCauseCodeShallow(member, seen);
+        if (nested) return nested;
+      }
+    }
+
+    current = (current as { cause?: unknown }).cause;
+  }
+  return code;
+}
+
+/** Cause-chain walk for AggregateError members, sharing the cycle guard. */
+function rootCauseCodeShallow(error: unknown, seen: Set<unknown>): string | null {
+  let current: unknown = error;
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    const candidate = (current as { code?: unknown }).code;
+    if (typeof candidate === 'string' && candidate.length > 0) return candidate;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return null;
+}
+
+/** True when the failure is an `AbortSignal` firing rather than a transport error. */
+export function isAbortError(error: unknown): boolean {
+  if (error instanceof Error && error.name === 'AbortError') return true;
+  const message = error instanceof Error ? error.message : String(error);
+  return /abort/i.test(message);
+}
+
+/**
+ * A human-readable, actionable description of a failed `fetch`.
+ *
+ * @param error   The thrown value.
+ * @param timeoutHint Message to use when the failure was an abort (a timeout).
+ */
+export function describeFetchError(
+  error: unknown,
+  timeoutHint = 'timed out (port blocked by a firewall, or the daemon is not responding)'
+): string {
+  if (isAbortError(error)) return timeoutHint;
+
+  const message = error instanceof Error ? error.message : String(error);
+  const code = rootCauseCode(error);
+  if (!code) return message;
+
+  const hint = CODE_HINTS[code];
+  // "fetch failed" carries no information; lead with the code instead of it.
+  const base = message === 'fetch failed' ? code : `${message} (${code})`;
+  return hint ? `${base} — ${hint}` : base;
+}

--- a/src/lib/seedbox/http-transport.ts
+++ b/src/lib/seedbox/http-transport.ts
@@ -3,6 +3,7 @@
  */
 
 import type { SeedboxHttpConfig } from './config';
+import { describeFetchError } from './fetch-error';
 
 export interface SendResult {
   ok: boolean;
@@ -40,8 +41,13 @@ export async function sendMagnetViaHttp(
       body: JSON.stringify(body),
     });
   } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
-    return { ok: false, transport: 'http', message: `Could not reach seedbox: ${detail}` };
+    // Report the underlying cause (ECONNREFUSED / ENOTFOUND / …), not undici's
+    // opaque "fetch failed" — they call for completely different fixes.
+    return {
+      ok: false,
+      transport: 'http',
+      message: `Could not reach seedbox: ${describeFetchError(error)}`,
+    };
   }
 
   if (!response.ok) {

--- a/src/lib/seedbox/provision.test.ts
+++ b/src/lib/seedbox/provision.test.ts
@@ -70,8 +70,56 @@ describe('seedbox provisioner', () => {
     it('installs a cron that self-updates torlink via `torlnk update`', () => {
       expect(script).toContain('torlink-autoupdate-media-streamer');
       expect(script).toContain('update >>'); // `"$BIN" update >> ...log`
-      expect(script).toContain('*/5 * * * *'); // every 5 min
       expect(script).toContain('NODE_BIN_DIR='); // pins PATH for cron
+    });
+
+    it('runs the updater hourly, not every 5 min (each run restarts the daemons)', () => {
+      // */5 meant 288 restart windows a day; the app sees ECONNREFUSED in each
+      // one. Liveness is the watchdog's job, not the updater's.
+      const updLine = script.match(/^UPD_LINE=.*$/m)?.[0] ?? '';
+      expect(updLine).toContain('17 * * * *');
+      expect(updLine).not.toContain('*/5 * * * *');
+    });
+
+    it('pins cron PATH to the real global bin dir, not dirname of a cli.cjs path', () => {
+      expect(script).toContain('GLOBAL_BIN_DIR="$(npm prefix -g 2>/dev/null)/bin"');
+      expect(script).not.toContain('GLOBAL_BIN_DIR=$(dirname "$BIN")');
+    });
+
+    it('supervises the daemons with systemd --user (Restart=always + linger)', () => {
+      expect(script).toContain('torlink-serve.service');
+      expect(script).toContain('torlink-files.service');
+      expect(script).toContain('Restart=always');
+      expect(script).toContain('enable-linger');
+      expect(script).toContain('systemctl --user enable --now');
+      // The unsupervised path must remain as a fallback.
+      expect(script).toContain('SUPERVISED=0');
+      expect(script).toContain('if [ "$SUPERVISED" = "1" ]; then');
+    });
+
+    it('installs a watchdog that restarts torlink when /health stops answering', () => {
+      expect(script).toContain('torlink-watchdog-media-streamer');
+      expect(script).toContain('.torlnk-watchdog.sh');
+      const wdLine = script.match(/^WD_LINE=.*$/m)?.[0] ?? '';
+      expect(wdLine).toContain('*/5 * * * *'); // liveness probe every 5 min
+      // Restarts via systemd when present, else relaunches the daemons directly.
+      expect(script).toContain('systemctl --user restart torlink-serve.service');
+      // The timestamp must be evaluated when the watchdog RUNS, not when the
+      // heredoc that writes it is expanded.
+      expect(script).toContain('\\$(date -Is)');
+    });
+
+    it('tears down supervisors before pkill so Restart=always cannot resurrect a daemon', () => {
+      const stopFn = script.match(/stop_torlink\(\)\{[\s\S]*?\n\}/)?.[0] ?? '';
+      expect(stopFn).toBeTruthy();
+      // Compare actual commands — comments mention both names, so matching the
+      // raw text would assert nothing about execution order.
+      const commands = stopFn
+        .split('\n')
+        .filter((line) => !line.trim().startsWith('#'))
+        .join('\n');
+      expect(commands).toContain('pkill');
+      expect(commands.indexOf('systemctl')).toBeLessThan(commands.indexOf('pkill'));
     });
 
     it('honors a custom seeding window and supports 0 = seed indefinitely', () => {

--- a/src/lib/seedbox/provision.ts
+++ b/src/lib/seedbox/provision.ts
@@ -3,9 +3,16 @@
  *
  * Given an account's SSH-connected seedbox, install the `torlnk` CLI
  * (`npm i -g torlnk`), start its HTTP add-API (`serve`, :9161) and file server
- * (`files`, :9160) as daemons bound to a generated bearer token, and open those
- * ports in the box's firewall. On success the caller wires the resulting HTTP +
- * files endpoints into the account's seedbox config so the app can use them.
+ * (`files`, :9160) bound to a generated bearer token, and open those ports in
+ * the box's firewall. On success the caller wires the resulting HTTP + files
+ * endpoints into the account's seedbox config so the app can use them.
+ *
+ * The daemons run under systemd `--user` units with `Restart=always` and linger
+ * enabled, so they survive crashes and reboots; a cron watchdog re-launches them
+ * if the add-API stops answering (and covers boxes with no usable systemd
+ * `--user`, which fall back to unsupervised `--daemon`). Without that, any crash
+ * or reboot left the box permanently unreachable — the app could only report
+ * ECONNREFUSED until someone re-ran this installer by hand.
  *
  * The remote work runs as a single idempotent bash script fed to `bash -s` over
  * SSH (see {@link execRemote}). The script emits `STEP|name|status|detail` lines
@@ -163,12 +170,13 @@ mkdir -p "$WATCH" "$DATA"
 # the real cmdline is like "node .../torlnk/dist/cli.js serve", so
 # \`pkill -f 'torlnk serve'\` misses it.
 stop_torlink(){
-  # Match both spellings: the npm bin ("torlnk") and a local checkout ("torlink").
-  pkill -f 'torli?nk' 2>/dev/null || sudo -n pkill -f 'torli?nk' 2>/dev/null || true
+  # Order matters: tear down supervisors FIRST. Our own units set
+  # Restart=always, so a pkill before the disable would just be undone five
+  # seconds later and the resurrected daemon would hold the port against us.
   # Stop AND disable+remove any torlink unit: a leftover unit (from an old manual
   # install) that points at a stale checkout/token would otherwise resurrect the
   # wrong build on reboot and fight this provisioner's daemons for the ports. The
-  # provisioner owns the --daemon processes, so it must be the single authority.
+  # provisioner owns the daemons, so it must be the single authority.
   local U
   for U in $(systemctl list-units --all --type=service --no-legend 2>/dev/null | grep -i torl | awk '{print $1}'); do
     sudo -n systemctl disable --now "$U" 2>/dev/null || sudo -n systemctl stop "$U" 2>/dev/null || true
@@ -183,6 +191,9 @@ stop_torlink(){
   if command -v pm2 >/dev/null 2>&1; then
     pm2 delete $(pm2 jlist 2>/dev/null | grep -o '"name":"[^"]*torl[^"]*"' | cut -d'"' -f4) >/dev/null 2>&1 || true
   fi
+  # Only now that nothing will restart them: kill any stray processes.
+  # Match both spellings: the npm bin ("torlnk") and a local checkout ("torlink").
+  pkill -f 'torli?nk' 2>/dev/null || sudo -n pkill -f 'torli?nk' 2>/dev/null || true
 }
 free_port(){
   local SIG="$1" P="$2" PIDS PID
@@ -205,15 +216,93 @@ export TORLINK_FILES_TOKEN="$TOK"
 # limited seedbox line (torlink >= the version with TORLINK_MAX_DOWNLOADS;
 # harmlessly ignored by older builds).
 export TORLINK_MAX_DOWNLOADS=2
-if "$BIN" serve --host 0.0.0.0 --port "$SERVE_PORT" --token "$TOK" --to "$DATA" ${seedFlag}--daemon >/tmp/torlnk-serve.log 2>&1; then
-  emit serve ok "add-API on $SERVE_PORT (downloads: $DATA; ${seedDesc})"
+
+# --- start the daemons UNDER SUPERVISION ---
+# A bare \`--daemon\` process answers to nobody: a crash, an OOM kill or a reboot
+# takes the seedbox offline for good, and the app can only report ECONNREFUSED
+# until a human re-runs this installer. Prefer systemd --user units with
+# Restart=always (plus linger, so they come up at boot with nobody logged in);
+# fall back to \`--daemon\` only where systemd --user isn't usable.
+SUPERVISED=0
+UNIT_DIR="$HOME/.config/systemd/user"
+NODE_DIR=$(dirname "$(command -v node 2>/dev/null)" 2>/dev/null)
+UNIT_PATH="$NODE_DIR:$HOME/.local/bin:$HOME/.local/share/mise/shims:/usr/local/bin:/usr/bin:/bin"
+if command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/dev/null 2>&1; then
+  mkdir -p "$UNIT_DIR"
+  loginctl enable-linger "$USER" >/dev/null 2>&1 || sudo -n loginctl enable-linger "$USER" >/dev/null 2>&1 || true
+  cat > "$UNIT_DIR/torlink-serve.service" <<UNIT
+[Unit]
+Description=torlink add-API (media-streamer)
+After=network-online.target
+
+[Service]
+Type=simple
+Environment="PATH=$UNIT_PATH"
+Environment="TORLINK_API_TOKEN=$TOK"
+Environment="TORLINK_FILES_TOKEN=$TOK"
+Environment="TORLINK_MAX_DOWNLOADS=2"
+ExecStart=$BIN serve --host 0.0.0.0 --port $SERVE_PORT --token $TOK --to "$DATA" ${seedFlag}
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+UNIT
+  cat > "$UNIT_DIR/torlink-files.service" <<UNIT
+[Unit]
+Description=torlink file server (media-streamer)
+After=network-online.target
+
+[Service]
+Type=simple
+Environment="PATH=$UNIT_PATH"
+Environment="TORLINK_API_TOKEN=$TOK"
+Environment="TORLINK_FILES_TOKEN=$TOK"
+ExecStart=$BIN files --host 0.0.0.0 --port $FILES_PORT --token $TOK --dir "$DATA"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+UNIT
+  systemctl --user daemon-reload >/dev/null 2>&1 || true
+  if systemctl --user enable --now torlink-serve.service torlink-files.service >/tmp/torlnk-systemd.log 2>&1; then
+    SUPERVISED=1
+    emit supervise ok "systemd --user units with Restart=always + linger — torlink now recovers from crashes and reboots by itself"
+  else
+    emit supervise skip "systemd --user unavailable: $(tail -n 2 /tmp/torlnk-systemd.log 2>/dev/null | tr '\\n' ' ')"
+  fi
 else
-  emit serve fail "$(tail -n 3 /tmp/torlnk-serve.log 2>/dev/null | tr '\\n' ' ')"
+  emit supervise skip "no usable systemd --user on this box; falling back to unsupervised --daemon (the watchdog cron below covers restarts)"
 fi
-if "$BIN" files --host 0.0.0.0 --port "$FILES_PORT" --token "$TOK" --dir "$DATA" --daemon >/tmp/torlnk-files.log 2>&1; then
-  emit files ok "file server on $FILES_PORT (serving: $DATA)"
+
+if [ "$SUPERVISED" = "1" ]; then
+  # systemd start is async — wait for the port to actually bind before judging.
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    curl -fsS -m 2 "http://127.0.0.1:$SERVE_PORT/health" >/dev/null 2>&1 && break
+    sleep 1
+  done
+  if curl -fsS -m 3 "http://127.0.0.1:$SERVE_PORT/health" >/dev/null 2>&1; then
+    emit serve ok "add-API on $SERVE_PORT via systemd (downloads: $DATA; ${seedDesc})"
+  else
+    emit serve fail "torlink-serve.service started but nothing answered on $SERVE_PORT — run 'systemctl --user status torlink-serve' on the box"
+  fi
+  if [ "$(curl -s -o /dev/null -m 5 -w '%{http_code}' -H "Authorization: Bearer $TOK" "http://127.0.0.1:$FILES_PORT/" 2>/dev/null || echo 000)" != "000" ]; then
+    emit files ok "file server on $FILES_PORT via systemd (serving: $DATA)"
+  else
+    emit files fail "torlink-files.service started but nothing answered on $FILES_PORT — run 'systemctl --user status torlink-files' on the box"
+  fi
 else
-  emit files fail "$(tail -n 3 /tmp/torlnk-files.log 2>/dev/null | tr '\\n' ' ')"
+  if "$BIN" serve --host 0.0.0.0 --port "$SERVE_PORT" --token "$TOK" --to "$DATA" ${seedFlag}--daemon >/tmp/torlnk-serve.log 2>&1; then
+    emit serve ok "add-API on $SERVE_PORT (downloads: $DATA; ${seedDesc})"
+  else
+    emit serve fail "$(tail -n 3 /tmp/torlnk-serve.log 2>/dev/null | tr '\\n' ' ')"
+  fi
+  if "$BIN" files --host 0.0.0.0 --port "$FILES_PORT" --token "$TOK" --dir "$DATA" --daemon >/tmp/torlnk-files.log 2>&1; then
+    emit files ok "file server on $FILES_PORT (serving: $DATA)"
+  else
+    emit files fail "$(tail -n 3 /tmp/torlnk-files.log 2>/dev/null | tr '\\n' ' ')"
+  fi
 fi
 
 # --- open firewall ports ---
@@ -287,14 +376,45 @@ fi
 # when already current, and bails gracefully if the global prefix isn't writable.
 # cron has a bare PATH, so pin node + npm (same dir) + the global-bin dir.
 NODE_BIN_DIR=$(dirname "$(command -v node 2>/dev/null)" 2>/dev/null)
-GLOBAL_BIN_DIR=$(dirname "$BIN")
+# The global npm bin dir — NOT \`dirname "$BIN"\`, which lands in .../dist when
+# $BIN fell back to cli.cjs and would leave npm/torlnk off cron's PATH.
+GLOBAL_BIN_DIR="$(npm prefix -g 2>/dev/null)/bin"
+
+# The updater restarts both daemons whenever it installs a release, so every run
+# is a small outage window. At */5 that was 288 chances a day to be caught
+# mid-restart (the app just sees ECONNREFUSED), and a restart that half-failed
+# stayed broken because the NEXT run finds the version current and no-ops.
+# Hourly is plenty for picking up releases; the watchdog below owns liveness.
 UPD_MARK="# torlink-autoupdate-media-streamer"
-UPD_LINE="*/5 * * * * PATH=\\"$NODE_BIN_DIR:$GLOBAL_BIN_DIR:/usr/local/bin:/usr/bin:/bin\\" \\"$BIN\\" update >> \\"$HOME/.torlnk-update.log\\" 2>&1 $UPD_MARK"
+UPD_LINE="17 * * * * PATH=\\"$NODE_BIN_DIR:$GLOBAL_BIN_DIR:/usr/local/bin:/usr/bin:/bin\\" \\"$BIN\\" update >> \\"$HOME/.torlnk-update.log\\" 2>&1 $UPD_MARK"
+
+# --- watchdog: the thing that actually keeps the seedbox reachable ---
+# Probes the add-API and restarts torlink if it stops answering — covering the
+# gap systemd can't (a wedged-but-alive process) and the case where systemd
+# --user wasn't available at all.
+WD="$HOME/.torlnk-watchdog.sh"
+cat > "$WD" <<WDEOF
+#!/usr/bin/env bash
+# Installed by media-streamer. Restarts torlink when its add-API stops answering.
+export PATH="$UNIT_PATH"
+curl -fsS -m 5 "http://127.0.0.1:$SERVE_PORT/health" >/dev/null 2>&1 && exit 0
+echo "\\$(date -Is) /health did not answer on $SERVE_PORT — restarting torlink" >> "$HOME/.torlnk-watchdog.log"
+systemctl --user restart torlink-serve.service torlink-files.service >/dev/null 2>&1 && exit 0
+export TORLINK_API_TOKEN="$TOK"
+export TORLINK_FILES_TOKEN="$TOK"
+export TORLINK_MAX_DOWNLOADS=2
+"$BIN" serve --host 0.0.0.0 --port "$SERVE_PORT" --token "$TOK" --to "$DATA" ${seedFlag}--daemon >/dev/null 2>&1 || true
+"$BIN" files --host 0.0.0.0 --port "$FILES_PORT" --token "$TOK" --dir "$DATA" --daemon >/dev/null 2>&1 || true
+WDEOF
+chmod +x "$WD" 2>/dev/null || true
+WD_MARK="# torlink-watchdog-media-streamer"
+WD_LINE="*/5 * * * * \\"$WD\\" >/dev/null 2>&1 $WD_MARK"
+
 if command -v crontab >/dev/null 2>&1; then
-  if ( crontab -l 2>/dev/null | grep -vF "$UPD_MARK"; echo "$UPD_LINE" ) | crontab - 2>/dev/null; then
-    emit autoupdate ok "torlnk update runs every 5 min (self-installs new releases + restarts daemons)"
+  if ( crontab -l 2>/dev/null | grep -vF "$UPD_MARK" | grep -vF "$WD_MARK"; echo "$UPD_LINE"; echo "$WD_LINE" ) | crontab - 2>/dev/null; then
+    emit autoupdate ok "torlnk update runs hourly; a health watchdog re-launches torlink every 5 min if it stops answering"
   else
-    emit autoupdate skip "couldn't install the auto-update cron; run 'torlnk update' to upgrade manually"
+    emit autoupdate skip "couldn't install the auto-update/watchdog cron; run 'torlnk update' to upgrade manually"
   fi
 else
   emit autoupdate skip "no crontab on the box; run 'torlnk update' to upgrade manually"


### PR DESCRIPTION
## Why

The seedbox went unreachable and stayed that way. The only thing the UI could say was:

> Couldn't reach torlink: fetch failed. Check the seedbox is up and the ports are open

That message sent us at the firewall, which turned out to be the wrong suspect. Three independent causes:

## 1. Nothing supervised the daemons

`stop_torlink` disables and **deletes** every torlink systemd unit and pm2 entry, then the provisioner started `serve`/`files` as bare detached `--daemon` processes — with no replacement supervisor and no `@reboot` hook. A crash, an OOM kill or a reboot took the box offline **permanently**, until someone re-ran the installer by hand.

Now: systemd `--user` units with `Restart=always` + `RestartSec=5`, and `enable-linger` so they come up at boot with nobody logged in. Boxes without a usable systemd `--user` still fall back to `--daemon`, covered by the watchdog below.

## 2. The self-updater was the thing knocking it over

`torlnk update` restarts both daemons whenever it installs a release, and it ran at `*/5` — 288 restart windows a day, each an `ECONNREFUSED` for anything polling. Worse, a restart that half-failed **stayed** broken: the next run found the version current and no-opped instead of healing it. That is the "worked, then stopped, and stays stopped" shape exactly.

Now: the updater runs hourly, and a separate watchdog owns liveness — every 5 min it probes `/health` and restarts torlink (via systemd, else by relaunching) if it stopped answering. That also catches a wedged-but-alive process, which `Restart=always` cannot.

## 3. Every failure rendered as the same two useless words

undici throws `TypeError: fetch failed` for refused connections, dead DNS, unreachable hosts and TLS faults alike, hiding the actual reason in `error.cause.code`. All three call sites (`status`, `test`, `http-transport`) read `error.message` only and dropped it — so a down daemon and a wrong hostname were indistinguishable.

Verified on Node:

| Failure | `error.message` | `error.cause.code` |
|---|---|---|
| Port closed | `fetch failed` | `ECONNREFUSED` |
| Host/DNS gone | `fetch failed` | `ENOTFOUND` |
| Firewall dropping packets | `This operation was aborted` | — |

Note the third row: a **timeout is not "fetch failed"**. Because we were seeing the literal string `fetch failed`, this was never a packet-dropping cloud firewall — it was a fast TCP-level refusal, i.e. nothing listening. New `describeFetchError` walks the cause chain (including `AggregateError` from happy-eyeballs) and pairs the code with the remedy: `ECONNREFUSED — nothing is listening on that port…`. Aborts stay reported as timeouts, since the two imply opposite diagnoses.

## Also

- `GLOBAL_BIN_DIR` used `dirname "$BIN"`, which lands in `.../dist` (not a bin dir) whenever `$BIN` fell back to `cli.cjs` — leaving `npm`/`torlnk` off cron's `PATH`. Now uses `npm prefix -g`.
- `stop_torlink` reordered to tear down supervisors **before** `pkill`, so `Restart=always` can't resurrect a daemon mid-teardown and fight the provisioner for the port.

## Testing

- Full suite green: **177 files, 2443 passed**, 7 skipped (also green through the pre-commit hook).
- `tsc --noEmit` clean; lint has 0 errors and no new warnings in any touched file.
- Generated provisioning script `bash -n` parses in both the default and `--seed-time 0` variants — it has nested heredocs inside a TS template literal, so this is worth checking.
- Watchdog exercised end to end: generated it with fake vars, confirmed it detects a dead port, logs with a **run-time** timestamp (`\$(date -Is)` correctly escaped, not expanded at heredoc creation), and falls through to the relaunch path.
- 15 new unit tests across `fetch-error` and the provisioner.

⚠️ One caveat: the added test file pushes the parallel suite slightly, and I saw two pre-existing e2e tests (`email-accounts-section`, `rss-content`) intermittently trip their 5s timeout under that load. They pass in isolation, pass on clean master, and passed on 3 of 4 full runs with these changes. Not caused by this branch logically, but their timeout is tight enough to be worth raising separately.

## Deploying this

These changes only take effect on a box when the installer re-runs — click **Install torlink & open ports** in Setup to re-provision. That will also tell you which of the three causes hit us, since the new `supervise` step reports what it managed to set up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)