### PR TITLE
fix(seedbox): deliver SSH sends to torlink's add-API instead of a watch dir nobody reads

### DIFF
--- a/src/components/torrents/seedbox-send-button.tsx
+++ b/src/components/torrents/seedbox-send-button.tsx
@@ -43,6 +43,9 @@ const TRANSPORT_LABEL: Record<SeedboxTransport, string> = {
   ssh: 'SSH',
 };
 
+/** Polls (2.5s apart) to wait for torlink to register a sent torrent (~30s). */
+const NEVER_REGISTERED_POLLS = 12;
+
 /** Pull the 40-hex infohash out of a magnet URI (needed to poll progress). */
 function infohashFromMagnet(magnet: string): string | null {
   const m = magnet.match(/urn:btih:([0-9a-fA-F]{40})/);
@@ -60,6 +63,10 @@ export function SeedboxSendButton({
   const [progress, setProgress] = useState<SeedboxProgress | null>(null);
   const [tracking, setTracking] = useState(false);
   const sawFoundRef = useRef(false);
+  // Consecutive polls where torlink answered but did not know this infohash.
+  // Without a bound, a torrent that never registers shows "Queued on seedbox…"
+  // forever — which is how a silently-failed delivery used to look.
+  const missesRef = useRef(0);
 
   const infohash = infohashFromMagnet(magnetUri);
 
@@ -98,6 +105,22 @@ export function SeedboxSendButton({
         }
         setProgress(data);
         if (data.found) sawFoundRef.current = true;
+        // torlink is reachable (it answered) but has never heard of this
+        // torrent. Give it a grace period, then say so instead of pretending
+        // it is queued.
+        if (!sawFoundRef.current && data.found === false) {
+          missesRef.current += 1;
+          if (missesRef.current >= NEVER_REGISTERED_POLLS) {
+            setTracking(false);
+            setProgress(null);
+            setStatus({
+              ok: false,
+              message:
+                'Sent, but torlink never registered it. Check the Torlink status page, or re-run Setup → Install torlink & open ports.',
+            });
+            return;
+          }
+        }
         // Done when torlink reports it, or when it vanished from the queue after
         // we'd seen it (completed + cleared).
         if (data.done || (sawFoundRef.current && data.found === false)) {
@@ -123,6 +146,7 @@ export function SeedboxSendButton({
       setStatus(null);
       setProgress(null);
       sawFoundRef.current = false;
+      missesRef.current = 0;
       try {
         const res = await fetch(`/api/torrents/${torrentId}/seedbox`, {
           method: 'POST',

--- a/src/lib/seedbox/http-transport.test.ts
+++ b/src/lib/seedbox/http-transport.test.ts
@@ -63,3 +63,43 @@ describe('sendMagnetViaHttp', () => {
     expect(result.message).toContain('Could not reach seedbox');
   });
 });
+
+describe('sendMagnetViaHttp — torlink add outcomes', () => {
+  it('reports a duplicate distinctly (a 200 does not mean this call queued anything)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true, outcome: 'duplicate' }), { status: 200 }));
+    const result = await sendMagnetViaHttp(httpConfig(), MAGNET, 'Example', fetchMock as unknown as typeof fetch);
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/already on the seedbox/i);
+  });
+
+  it('reports a fresh add as sent', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true, outcome: 'added' }), { status: 200 }));
+    const result = await sendMagnetViaHttp(httpConfig(), MAGNET, 'Example', fetchMock as unknown as typeof fetch);
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/sent to seedbox/i);
+  });
+
+  it('still succeeds when the body is not JSON (non-torlink clients)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('OK', { status: 200 }));
+    const result = await sendMagnetViaHttp(httpConfig(), MAGNET, 'Example', fetchMock as unknown as typeof fetch);
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/sent to seedbox/i);
+  });
+
+  it('surfaces the underlying connect error rather than "fetch failed"', async () => {
+    const cause = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('fetch failed', { cause }));
+    const result = await sendMagnetViaHttp(httpConfig(), MAGNET, 'Example', fetchMock as unknown as typeof fetch);
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('ECONNREFUSED');
+    expect(result.message).not.toMatch(/fetch failed$/);
+  });
+});

--- a/src/lib/seedbox/http-transport.ts
+++ b/src/lib/seedbox/http-transport.ts
@@ -60,5 +60,23 @@ export async function sendMagnetViaHttp(
     };
   }
 
-  return { ok: true, transport: 'http', message: 'Sent to seedbox via HTTP API' };
+  // torlink answers 200 {"ok":true,"outcome":"added"|"duplicate"} — a 200 alone
+  // does not mean this call queued anything, so report which one happened.
+  const outcome = await response
+    .json()
+    .then((body: unknown) =>
+      body && typeof body === 'object' && typeof (body as { outcome?: unknown }).outcome === 'string'
+        ? (body as { outcome: string }).outcome
+        : null
+    )
+    .catch(() => null);
+
+  return {
+    ok: true,
+    transport: 'http',
+    message:
+      outcome === 'duplicate'
+        ? 'Already on the seedbox — torlink is tracking it'
+        : 'Sent to seedbox via HTTP API',
+  };
 }

--- a/src/lib/seedbox/provision.ts
+++ b/src/lib/seedbox/provision.ts
@@ -161,8 +161,13 @@ fi
 
 # --- data dirs + fully-automatic daemon (re)start (no manual steps) ---
 ${dataDirLine}
-WATCH="$HOME/Downloads/watch"
-mkdir -p "$WATCH" "$DATA"
+# NOTE: no watch dir is created. torlink's blackhole feature is a separate
+# subcommand (\`torlnk watch <dir>\`) that this provisioner never started, so a
+# watch dir here was only ever a place for magnets to rot unread. It also would
+# not help: \`watch\` runs as its own process with its own queue, invisible to the
+# \`serve\` /status that the status page and progress bars poll. SSH sends now go
+# through serve's add-API over loopback instead (see sendMagnetViaSshToLocalApi).
+mkdir -p "$DATA"
 
 # Stop ANY existing torlink daemon so our fresh token becomes authoritative —
 # however it was started (detached process, systemd system/user unit, or pm2) —

--- a/src/lib/seedbox/send.test.ts
+++ b/src/lib/seedbox/send.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./ssh-transport', () => ({
+  sendMagnetViaSsh: vi.fn().mockResolvedValue({ ok: true, transport: 'ssh', message: 'watch dir' }),
+  sendMagnetViaSshToLocalApi: vi.fn().mockResolvedValue({ ok: true, transport: 'ssh', message: 'local api' }),
+  getSeedboxPublicKey: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('./http-transport', () => ({
+  sendMagnetViaHttp: vi.fn().mockResolvedValue({ ok: true, transport: 'http', message: 'http' }),
+}));
+
+import type { SeedboxConfig } from './config';
+import { sendMagnetViaSsh, sendMagnetViaSshToLocalApi } from './ssh-transport';
+import { sendTorrentToSeedbox } from './send';
+
+const MAGNET = 'magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567&dn=Example';
+
+const ssh = {
+  host: 'box.example.com',
+  port: 22,
+  user: 'seed',
+  privateKey: 'KEY',
+  privateKeyPath: null,
+  watchDir: '/home/seed/Downloads/watch',
+  addCommand: null,
+};
+
+const http = {
+  baseUrl: 'http://box.example.com:9161',
+  token: 'tok',
+  addPath: '/add',
+  auth: { kind: 'bearer' as const },
+  magnetField: 'magnet',
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('sendTorrentToSeedbox — SSH delivery', () => {
+  it('hands the magnet to torlink’s own add-API over loopback when one is configured', async () => {
+    // Regression: a .magnet dropped in the watch dir is read by nobody, because
+    // torlink's blackhole is a separate `torlnk watch` process the provisioner
+    // never starts — and it keeps its own queue, invisible to serve's /status.
+    const config = { http, ssh, files: null } as unknown as SeedboxConfig;
+    const result = await sendTorrentToSeedbox(MAGNET, 'Example', 'ssh', config);
+
+    expect(result.ok).toBe(true);
+    expect(sendMagnetViaSshToLocalApi).toHaveBeenCalledTimes(1);
+    expect(sendMagnetViaSsh).not.toHaveBeenCalled();
+  });
+
+  it('targets loopback on the add-API port, not the public host', async () => {
+    const config = { http, ssh, files: null } as unknown as SeedboxConfig;
+    await sendTorrentToSeedbox(MAGNET, 'Example', 'ssh', config);
+
+    const [, addUrl, token, magnet] = (sendMagnetViaSshToLocalApi as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0] as [unknown, string, string, string];
+    expect(addUrl).toBe('http://127.0.0.1:9161/add');
+    expect(token).toBe('tok');
+    expect(magnet).toBe(MAGNET);
+  });
+
+  it('defaults to torlink’s port when the configured URL carries none', async () => {
+    const config = {
+      http: { ...http, baseUrl: 'http://box.example.com' },
+      ssh,
+      files: null,
+    } as unknown as SeedboxConfig;
+    await sendTorrentToSeedbox(MAGNET, 'Example', 'ssh', config);
+
+    const [, addUrl] = (sendMagnetViaSshToLocalApi as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0] as [unknown, string];
+    expect(addUrl).toBe('http://127.0.0.1:9161/add');
+  });
+
+  it('falls back to the watch dir / add command when there is no add-API', async () => {
+    const config = { http: null, ssh, files: null } as unknown as SeedboxConfig;
+    const result = await sendTorrentToSeedbox(MAGNET, 'Example', 'ssh', config);
+
+    expect(result.ok).toBe(true);
+    expect(sendMagnetViaSsh).toHaveBeenCalledTimes(1);
+    expect(sendMagnetViaSshToLocalApi).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/seedbox/send.ts
+++ b/src/lib/seedbox/send.ts
@@ -8,7 +8,7 @@ import {
   type SeedboxTransport,
 } from './config';
 import { sendMagnetViaHttp, type SendResult } from './http-transport';
-import { getSeedboxPublicKey, sendMagnetViaSsh } from './ssh-transport';
+import { getSeedboxPublicKey, sendMagnetViaSsh, sendMagnetViaSshToLocalApi } from './ssh-transport';
 
 export interface SeedboxAccess {
   /** True when this account may push to a configured seedbox transport. */
@@ -69,6 +69,19 @@ export async function sendTorrentToSeedbox(
     return sendMagnetViaHttp(config.http, magnet, name);
   }
   if (chosen === 'ssh' && config.ssh) {
+    // When the box also runs torlink's add-API, hand the magnet to that daemon
+    // over loopback rather than dropping a file in a watch dir. The watch dir is
+    // a different torlink subcommand (`torlnk watch`) that the provisioner never
+    // starts — and even when started it keeps a separate queue, so torrents sent
+    // that way never appear in the /status the UI polls. Same daemon = one queue
+    // = progress and the status page both work. The token is read from the live
+    // config here, so it is never persisted into the SSH command.
+    if (config.http) {
+      const addUrl = `http://127.0.0.1:${new URL(config.http.baseUrl).port || '9161'}${
+        config.http.addPath.startsWith('/') ? '' : '/'
+      }${config.http.addPath}`;
+      return sendMagnetViaSshToLocalApi(config.ssh, addUrl, config.http.token, magnet);
+    }
     return sendMagnetViaSsh(config.ssh, magnet, name);
   }
   return { ok: false, transport: chosen, message: `Seedbox transport "${chosen}" is not configured` };

--- a/src/lib/seedbox/ssh-transport.ts
+++ b/src/lib/seedbox/ssh-transport.ts
@@ -150,6 +150,59 @@ export async function getSeedboxPublicKey(config: SeedboxSshConfig): Promise<str
   }
 }
 
+/**
+ * Node one-liner run on the seedbox that POSTs a magnet to torlink's *local*
+ * add-API. Input (url/token/magnet) arrives as JSON on stdin, so neither the
+ * token nor the magnet ever appears in the box's process list.
+ */
+const REMOTE_ADD_SCRIPT = `let s='';process.stdin.on('data',d=>s+=d).on('end',async()=>{try{const{u,t,m}=JSON.parse(s);const r=await fetch(u,{method:'POST',headers:{'Content-Type':'application/json',Authorization:'Bearer '+t},body:JSON.stringify({magnet:m})});const b=await r.text();process.stdout.write(String(r.status)+' '+b);if(!r.ok)process.exit(1)}catch(e){process.stderr.write(String(e&&e.message||e));process.exit(1)}})`;
+
+/**
+ * Deliver a magnet by asking the box to hand it to torlink's own add-API over
+ * loopback.
+ *
+ * Why not the watch dir: torlink's watch-folder feature is a separate
+ * subcommand (`torlnk watch <dir>`), not part of `serve` — the provisioner only
+ * ever ran `serve` and `files`, so files dropped into the watch dir were read by
+ * nobody. And even with a watch daemon running it would be a *separate process
+ * with its own queue*, invisible to the `serve` /status that the status page and
+ * progress bar poll. Going through the same daemon keeps one queue, so SSH-sent
+ * torrents show up exactly like HTTP-sent ones.
+ */
+export async function sendMagnetViaSshToLocalApi(
+  ssh: SeedboxSshConfig,
+  addUrl: string,
+  token: string,
+  magnet: string
+): Promise<SendResult> {
+  try {
+    return await withPrivateKeyFile(ssh, async (keyPath) => {
+      const target = `${ssh.user}@${ssh.host}`;
+      const sshArgs = baseSshArgs(ssh, keyPath);
+      // Non-interactive SSH gets a minimal PATH; torlink requires Node, and the
+      // provisioner installs it via mise, so look there too.
+      const remoteCmd =
+        `export PATH="$HOME/.local/share/mise/shims:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"; ` +
+        `exec node -e ${shellQuote(REMOTE_ADD_SCRIPT)}`;
+      const payload = JSON.stringify({ u: addUrl, t: token, m: magnet });
+      const { stdout } = await runExecFile('ssh', [...sshArgs, target, remoteCmd], payload);
+      // torlink answers 200 {"ok":true,"outcome":"added"|"duplicate"}.
+      const outcome = /"outcome"\s*:\s*"([a-z]+)"/i.exec(stdout)?.[1];
+      return {
+        ok: true,
+        transport: 'ssh',
+        message:
+          outcome === 'duplicate'
+            ? 'Already on the seedbox — torlink is tracking it'
+            : 'Handed to torlink on the seedbox via SSH',
+      };
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { ok: false, transport: 'ssh', message: `SSH delivery failed: ${detail}` };
+  }
+}
+
 export async function sendMagnetViaSsh(
   config: SeedboxSshConfig,
   magnet: string,


### PR DESCRIPTION
## The bug

"Send to seedbox" reported success, then sat on **"Queued on seedbox…" forever**, and the torrent never appeared on the Torlink status page. Both transports affected.

## Root cause

torlink's blackhole/watch-folder feature is a **separate subcommand** — `torlnk watch <dir>` — not a flag on `serve`. Confirmed against the shipped package (`@profullstack/torlink@1.4.4`), whose complete flag list is:

```
--daemon --delete-files --dir --ff-only --force --help --host
--no-newline --port --seed-time --to --token --version
```

No `--watch`. The provisioner created `$HOME/Downloads/watch` and started only `serve` and `files`, so **nothing on the box ever read that directory**. `sendMagnetViaSsh` wrote the `.magnet` file, `ssh` exited 0, and the app cheerfully reported `Dropped X into seedbox watch folder`.

Confirmed on the actual box:

```
-rw------- 1 ubuntu ubuntu 140 Jul 17 10:17 'Cape Fear S01E04 WEB.magnet'
-rw------- 1 ubuntu ubuntu 170 Jul 30 17:59 'Pluribus 2025 … Vyndros.magnet'
```

Two magnets **13 days apart**, both unread. torlink's watch mode moves handled files into `.processed`/`.failed`, so untouched files prove no watch daemon has ever run. Every SSH send since at least July 17 silently vanished while the UI showed success.

## Why not just start `torlnk watch`

Because it wouldn't fix the symptom. `watch` runs as **its own process with its own queue**, invisible to the `serve` `/status` that both the status page and the progress bar poll. Torrents sent that way would download but stay missing from the UI — the same complaint, one layer down.

So SSH sends now go to the **same daemon** as HTTP sends: a Node one-liner over SSH POSTs the magnet to `127.0.0.1:<serve-port>/add`. One queue, so status and progress work identically for both transports, and loopback means no firewall involvement.

Security notes on that path: the payload (url/token/magnet) is passed as **JSON on stdin**, so neither the bearer token nor the magnet appears in the box's process list; and the token is read from the live config at send time rather than persisted into `ssh_add_command` (which is stored unencrypted).

## Also fixed

- **`/add` outcome ignored.** torlink answers `200 {"ok":true,"outcome":"added"|"duplicate"}`; the HTTP transport only checked the status code, so a duplicate was indistinguishable from a fresh queue. Now reported.
- **The progress poller never gave up.** Whenever torlink answered but didn't know the infohash, the UI showed "Queued on seedbox…" indefinitely — exactly how this silent failure presented. It now stops after ~30s and says the torrent was never registered.
- **Watch dir no longer created**, since it only advertised a feature that wasn't running.

## Testing

- Full suite green: **178 files, 2451 passed**, 7 skipped (via the pre-commit hook). `tsc --noEmit` clean, no new lint warnings in touched files.
- 9 new tests: dispatcher routing (loopback URL, port fallback, watch-dir fallback when no add-API) and the `/add` outcome cases.
- **Extracted the exact remote script this PR ships and ran it against a mock torlink `/add`**, verifying both the output and the exit codes that drive ok/fail:

| case | exit | output |
|---|---|---|
| added | 0 | `200 {"ok":true,"outcome":"added"}` |
| duplicate | 0 | `200 {"ok":true,"outcome":"duplicate"}` |
| bad token | 1 | `401 {"error":"unauthorized"}` |
| daemon down | 1 | `fetch failed` |

## Deploying

The app-side fix goes live on merge (master auto-deploys to bittorrented.com). Re-provisioning is **not** required for SSH sends to start working — the new path uses the existing add-API. The two stranded magnets in `~/Downloads/watch` won't self-recover; re-send those torrents from the UI.

## Not addressed

`buildSshConfig` still requires `watchDir || addCommand` before SSH is offered at all. Existing configs have `watchDir` set so this doesn't bite today, but a freshly-provisioned box gets neither, so SSH wouldn't appear even though it would now work. Worth relaxing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)