### PR TITLE
fix(seedbox): make re-installing torlink actually leave a daemon that stays up

### DIFF
--- a/src/lib/seedbox/provision.test.ts
+++ b/src/lib/seedbox/provision.test.ts
@@ -171,3 +171,49 @@ describe('seedbox provisioner', () => {
     });
   });
 });
+
+describe('seedbox provisioner — install must leave a daemon that stays up', () => {
+  const script = buildProvisionScript('TOK123_-', DEFAULT_SERVE_PORT, DEFAULT_FILES_PORT);
+
+  it('disables systemd’s start rate limit so a crash loop never lands in failed', () => {
+    // Default is 5 starts / 10s, after which systemd gives up permanently —
+    // recreating the exact dead-daemon state these units exist to prevent.
+    expect(script).toContain('StartLimitIntervalSec=0');
+    // Once per unit ([Unit] section of serve and files).
+    expect(script.match(/StartLimitIntervalSec=0/g)).toHaveLength(2);
+  });
+
+  it('clears failed state before the watchdog restarts (restart refuses otherwise)', () => {
+    const wd = script.match(/cat > "\$WD" <<WDEOF[\s\S]*?WDEOF/)?.[0] ?? '';
+    expect(wd).toContain('reset-failed');
+    expect(wd.indexOf('reset-failed')).toBeLessThan(wd.indexOf('systemctl --user restart'));
+  });
+
+  it('re-probes after a delay so a daemon that dies immediately is not reported ok', () => {
+    expect(script).toContain('emit stable ok');
+    expect(script).toContain('emit stable fail');
+    // The re-probe must come after a wait, not back-to-back with the first check.
+    const stable = script.indexOf('--- does it STAY up? ---');
+    expect(stable).toBeGreaterThan(-1);
+    expect(script.slice(stable, stable + 400)).toMatch(/sleep \d+/);
+  });
+
+  it('reports why a dead daemon died instead of a bare "did not answer"', () => {
+    expect(script).toContain('why_dead()');
+    expect(script).toContain('journalctl --user -u torlink-serve.service');
+    expect(script).toContain('$(why_dead)');
+  });
+
+  it('imports magnets stranded in the legacy watch folder', () => {
+    expect(script).toContain('LEGACY_WATCH="$HOME/Downloads/watch"');
+    expect(script).toContain('emit rescue ok');
+    expect(script).toContain('.processed');
+    // Body built via node, so a magnet with quotes cannot break the JSON.
+    expect(script).toContain('JSON.stringify({magnet:m})');
+  });
+
+  it('still does not create a watch dir (nothing reads it)', () => {
+    expect(script).not.toContain('mkdir -p "$WATCH"');
+    expect(script).not.toContain('WATCH="$HOME/Downloads/watch"\nmkdir');
+  });
+});

--- a/src/lib/seedbox/provision.ts
+++ b/src/lib/seedbox/provision.ts
@@ -239,6 +239,10 @@ if command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/d
 [Unit]
 Description=torlink add-API (media-streamer)
 After=network-online.target
+# Never stop retrying. systemd's default rate limit (5 starts / 10s) would put a
+# crash-looping torlink into 'failed' permanently — which is precisely the dead
+# daemon this unit exists to prevent.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
@@ -257,6 +261,10 @@ UNIT
 [Unit]
 Description=torlink file server (media-streamer)
 After=network-online.target
+# Never stop retrying. systemd's default rate limit (5 starts / 10s) would put a
+# crash-looping torlink into 'failed' permanently — which is precisely the dead
+# daemon this unit exists to prevent.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
@@ -326,10 +334,60 @@ fi
 
 # --- health check ---
 sleep 2
+# Collect whatever the box can tell us about a daemon that would not stay up:
+# the systemd journal when supervised, otherwise torlink's own logs.
+why_dead(){
+  if [ "$SUPERVISED" = "1" ]; then
+    journalctl --user -u torlink-serve.service -n 6 --no-pager 2>/dev/null | tr '\\n' ' '
+  else
+    tail -n 6 /tmp/torlnk-serve.log 2>/dev/null | tr '\\n' ' '
+  fi
+}
+
 if curl -fsS "http://127.0.0.1:$SERVE_PORT/health" >/tmp/torlnk-health 2>/dev/null; then
   emit health ok "$(cat /tmp/torlnk-health 2>/dev/null | tr '\\n' ' ')"
 else
-  emit health fail "serve did not answer /health yet — check /tmp/torlnk-serve.log on the box"
+  emit health fail "serve did not answer /health — $(why_dead)"
+fi
+
+# --- does it STAY up? ---
+# An immediate health check only proves torlink started. It has been dying
+# shortly after launch (the box was found with no torlnk process at all), and a
+# provisioner that reports success for a daemon which is already gone is worse
+# than useless. Re-probe after a delay and report what killed it.
+sleep 12
+if curl -fsS -m 5 "http://127.0.0.1:$SERVE_PORT/health" >/dev/null 2>&1; then
+  emit stable ok "still serving 15s after start"
+else
+  emit stable fail "torlink started but died within ~15s — $(why_dead)"
+fi
+
+# --- rescue magnets stranded in the legacy watch dir ---
+# Older installs advertised $HOME/Downloads/watch as a blackhole, but nothing
+# ever read it: torlink's watch mode is a separate \`torlnk watch\` process this
+# provisioner never started. Every SSH send therefore piled up unread. Hand any
+# leftovers to the add-API now and move them aside so they are not re-imported.
+LEGACY_WATCH="$HOME/Downloads/watch"
+if [ -d "$LEGACY_WATCH" ]; then
+  RESCUED=0; STRAY_FAILED=0
+  for F in "$LEGACY_WATCH"/*.magnet "$LEGACY_WATCH"/*.txt; do
+    [ -f "$F" ] || continue
+    # Build the JSON with node so a magnet containing quotes/backslashes cannot
+    # break out of the body (node is guaranteed here — torlink requires it).
+    if node -e 'const fs=require("fs");const m=fs.readFileSync(process.argv[1],"utf8").trim();if(!/^magnet:/i.test(m))process.exit(2);fetch(process.argv[2],{method:"POST",headers:{"Content-Type":"application/json",Authorization:"Bearer "+process.argv[3]},body:JSON.stringify({magnet:m})}).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))' \
+         "$F" "http://127.0.0.1:$SERVE_PORT/add" "$TOK" 2>/dev/null; then
+      mkdir -p "$LEGACY_WATCH/.processed" 2>/dev/null || true
+      mv "$F" "$LEGACY_WATCH/.processed/" 2>/dev/null || true
+      RESCUED=$((RESCUED+1))
+    else
+      STRAY_FAILED=$((STRAY_FAILED+1))
+    fi
+  done
+  if [ "$RESCUED" -gt 0 ] || [ "$STRAY_FAILED" -gt 0 ]; then
+    emit rescue ok "imported $RESCUED magnet(s) stranded in the old watch folder ($STRAY_FAILED could not be read); moved to .processed"
+  else
+    emit rescue skip "no stranded magnets in the old watch folder"
+  fi
 fi
 
 # --- verify the freshly-generated token is the one actually answering ---
@@ -404,6 +462,10 @@ cat > "$WD" <<WDEOF
 export PATH="$UNIT_PATH"
 curl -fsS -m 5 "http://127.0.0.1:$SERVE_PORT/health" >/dev/null 2>&1 && exit 0
 echo "\\$(date -Is) /health did not answer on $SERVE_PORT — restarting torlink" >> "$HOME/.torlnk-watchdog.log"
+# Clear any 'failed' state first: systemctl restart refuses a unit that tripped
+# the start limit ("start request repeated too quickly"), so without this the
+# watchdog would silently no-op on exactly the boxes that need it most.
+systemctl --user reset-failed torlink-serve.service torlink-files.service >/dev/null 2>&1 || true
 systemctl --user restart torlink-serve.service torlink-files.service >/dev/null 2>&1 && exit 0
 export TORLINK_API_TOKEN="$TOK"
 export TORLINK_FILES_TOKEN="$TOK"


### PR DESCRIPTION
## Why

`ps aux | grep -i torl` on the seedbox returned **nothing** — no torlink process at all. That is the real cause behind both the original `ECONNREFUSED` and the sends that vanished.

PR #139 added systemd supervision to fix exactly that, but reviewing it against "what happens when the user actually clicks Install", I found three gaps that would let a re-install report success and still leave the box dead.

## 1. systemd would give up permanently

The units set `Restart=always` but left systemd's **default start rate limit** in place — 5 starts in 10s, after which the unit enters `failed` and is never restarted again. A crash-looping torlink would therefore end up in exactly the dead state the units exist to prevent.

`StartLimitIntervalSec=0` on both units → retry forever.

## 2. The watchdog could not recover it

The watchdog ran `systemctl --user restart`, which **refuses a unit that tripped the start limit** (`start request repeated too quickly`). So on precisely the boxes that needed it most, the watchdog silently no-opped. It now runs `reset-failed` first.

## 3. The installer only proved torlink *started*

It health-checked once, immediately after launch. A daemon that died ten seconds later still reported `ok` — which is how you end up with a green install and an unreachable seedbox.

There is now a `stable` step that re-probes after ~12s. Both failure paths report **why**, via `journalctl --user -u torlink-serve` when supervised or the serve log when not, instead of a bare "did not answer".

## Also: rescues the stranded magnets

Nothing ever read `~/Downloads/watch` (torlink's watch mode is a separate `torlnk watch` process this provisioner never started), so SSH sends piled up there unread — the box had two, **13 days apart**:

```
Jul 17 10:17  'Cape Fear S01E04 WEB.magnet'
Jul 30 17:59  'Pluribus 2025 … Vyndros.magnet'
```

The installer now POSTs any leftovers to the local add-API and moves them to `.processed`. The body is built with `node` rather than string interpolation, so a magnet containing quotes or backslashes cannot break out of the JSON.

## Testing

- Full suite green: **178 files, 2457 passed**, 7 skipped (via pre-commit hook). `tsc --noEmit` clean, no new lint warnings.
- 6 new provisioner tests (rate limit disabled on both units, `reset-failed` ordered before `restart`, the delayed re-probe, `why_dead` reporting, the rescue block, and that no watch dir is recreated).
- Generated script `bash -n` parses in both the default and `--seed-time 0` variants.
- **Ran the rescue block against a mock add-API**: two `.magnet` files — including one containing `"` and `\` — were accepted and moved to `.processed/`, while a non-magnet `junk.txt` was correctly left in place.

## What this means operationally

After merging, **Setup → Install torlink & open ports** should be sufficient on its own. Watch the step output:

| step | meaning |
|---|---|
| `supervise ok` | systemd units took — torlink now survives crashes and reboots |
| `stable ok` | still serving 15s after start (not just "it launched") |
| `rescue ok` | the stranded magnets were imported |
| `stable fail` | torlink is crashing for its own reason — the detail now says what |

If `stable fail` appears, that detail is the thing to act on; it means torlink itself is dying, not that provisioning went wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)