### PR TITLE
fix(seedbox): stop the status page hiding torrents that failed to start

### DIFF
--- a/src/lib/seedbox/torlink-reconcile.test.ts
+++ b/src/lib/seedbox/torlink-reconcile.test.ts
@@ -34,15 +34,45 @@ describe('isLiveTorrent', () => {
     expect(isLiveTorrent('queued', 'Not.On.Disk.Yet', disk)).toBe(true);
   });
 
-  it('keeps seeding/paused/failed only when their files still exist', () => {
+  it('keeps seeding/paused only when their files still exist', () => {
     expect(isLiveTorrent('seeding', 'Kept.Seed', disk)).toBe(true);
     expect(isLiveTorrent('seeding', 'Deleted.Seed', disk)).toBe(false);
     expect(isLiveTorrent('paused', 'Deleted.Seed', disk)).toBe(false);
-    expect(isLiveTorrent('failed', 'Deleted.Seed', disk)).toBe(false);
   });
 
   it('fails open (keeps items) when the disk listing is unavailable', () => {
     expect(isLiveTorrent('seeding', 'Deleted.Seed', null)).toBe(true);
     expect(isLiveTorrent('paused', 'Whatever', null)).toBe(true);
+  });
+});
+
+describe('isLiveTorrent — a torrent must never silently vanish', () => {
+  const disk = ['Kept.Seed'];
+
+  it('always shows a failed torrent, even with nothing on disk', () => {
+    // A torrent that errored has no files by definition, so disk-reconciling it
+    // hid every failure: adds that succeeded but could not start just
+    // disappeared from the page, with no way to tell they had ever arrived.
+    expect(isLiveTorrent('failed', 'Just.Added.No.Files', disk)).toBe(true);
+    expect(isLiveTorrent('failed', 'Just.Added.No.Files', [])).toBe(true);
+  });
+
+  it('shows in-flight states that have no files yet', () => {
+    for (const status of ['downloading', 'queued', 'connecting', 'metadata', 'checking']) {
+      expect(isLiveTorrent(status, 'Not.On.Disk.Yet', disk)).toBe(true);
+    }
+  });
+
+  it('shows a status it has never heard of rather than hiding it', () => {
+    // Allow-listing visible states would make any future torlink status vanish.
+    expect(isLiveTorrent('some-new-torlink-state', 'Not.On.Disk.Yet', disk)).toBe(true);
+    expect(isLiveTorrent('', 'Not.On.Disk.Yet', disk)).toBe(true);
+  });
+
+  it('still drops missing, and still reconciles stored torrents', () => {
+    expect(isLiveTorrent('missing', 'Kept.Seed', disk)).toBe(false);
+    expect(isLiveTorrent('seeding', 'Deleted.Seed', disk)).toBe(false);
+    expect(isLiveTorrent('paused', 'Deleted.Seed', disk)).toBe(false);
+    expect(isLiveTorrent('seeding', 'Kept.Seed', disk)).toBe(true);
   });
 });

--- a/src/lib/seedbox/torlink-reconcile.ts
+++ b/src/lib/seedbox/torlink-reconcile.ts
@@ -30,10 +30,22 @@ export function isOnDisk(name: string, onDiskNames: string[]): boolean {
 }
 
 /**
+ * States that describe live activity rather than stored data. None of these
+ * imply anything is on disk yet, so they must never be disk-reconciled.
+ *
+ * `failed` belongs here despite not being "active": a torrent that errored has
+ * no files by definition, so requiring files on disk hid every failure. That
+ * made a torrent added successfully but unable to start simply *vanish* from
+ * the page — the single most confusing way this can break, and precisely the
+ * state you most need to see. Surfacing it is the whole point.
+ */
+const DISK_BACKED = new Set(['seeding', 'paused']);
+
+/**
  * Keep only torrents that reflect the seedbox's *current* state:
  *  - drop torlink's `missing` records (data confirmed gone),
- *  - always keep active transfers (downloading / queued) — inherently realtime,
- *  - for the rest (seeding / paused / failed) keep only if the files are still
+ *  - always keep in-flight or errored torrents — none of them have files yet,
+ *  - for stored torrents (seeding / paused) keep only if the files are still
  *    on disk.
  *
  * `onDiskNames === null` means the listing couldn't be fetched, so we can't
@@ -41,7 +53,11 @@ export function isOnDisk(name: string, onDiskNames: string[]): boolean {
  */
 export function isLiveTorrent(status: string, name: string, onDiskNames: string[] | null): boolean {
   if (status === 'missing') return false;
-  if (status === 'downloading' || status === 'queued') return true;
+  // Reconcile ONLY the states that imply stored data. Anything else — including
+  // a status this code has never heard of — is shown. Allow-listing the visible
+  // states instead would make any new torlink status silently disappear, which
+  // is the failure mode this whole filter keeps producing.
+  if (!DISK_BACKED.has(status)) return true;
   if (onDiskNames === null) return true;
   return isOnDisk(name, onDiskNames);
 }


### PR DESCRIPTION
## The smoking gun

Torrents sent to the seedbox vanished — app reported success, the status page count never moved, nothing appeared.

Proof the adds **were** landing came from the installer's rescue step added in #141. It only moves a `.magnet` into `.processed/` **after** torlink answers 2xx to `/add`. On the box:

```
./.processed/Cape Fear S01E04 WEB.magnet
./.processed/Pluribus 2025 Season 1 S01 ATVP DDP 5 1 Vyndros.magnet
```

Both moved. So torlink accepted both — and the page was hiding them.

## Root cause

`isLiveTorrent` reconciled everything except `downloading`/`queued` against the file server's directory listing, keeping an item only if its files were already on disk.

A torrent that was accepted but **could not start has no files by definition**. So every failure got filtered out. The torrent didn't show as failed, didn't show as anything — it just disappeared, with no way to tell it had ever arrived. That's the most confusing possible failure mode, and `failed` is precisely the state you most need to see.

## The fix

Invert the rule. Reconcile **only** the states that imply stored data:

```ts
const DISK_BACKED = new Set(['seeding', 'paused']);

if (status === 'missing') return false;
if (!DISK_BACKED.has(status)) return true;   // show everything else
if (onDiskNames === null) return true;
return isOnDisk(name, onDiskNames);
```

Everything else is shown, **including statuses this code has never heard of**. I first wrote this as an allow-list of visible states and then changed it: an allow-list makes any *future* torlink status silently disappear the same way. This filter has now produced the vanishing bug twice, so the default must be to show.

Still correct for its original purpose: `missing` drops, and stale `seeding`/`paused` records whose files were deleted are still reconciled away.

## Testing

- Full suite green: **178 files, 2461 passed**, 7 skipped (pre-commit hook). `tsc --noEmit` clean, no new lint warnings.
- 4 new tests: `failed` shown with nothing on disk, in-flight states shown, an **unknown** status shown rather than hidden, and the original reconciliation still working.
- Updated one existing test that asserted the old (wrong) behaviour of hiding `failed`.

## What this changes for the user

Nothing about *why* a torrent fails — it makes the failure visible instead of silent. After deploying, Pluribus should appear on the Torlink status page with whatever state torlink actually has it in. That state is the next thing to act on, and it's been invisible this whole time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)