### PR TITLE
fix(seedbox): stop a hung request freezing the Torlink status page forever

### DIFF
--- a/src/app/seedboxes/torlink-status.tsx
+++ b/src/app/seedboxes/torlink-status.tsx
@@ -241,15 +241,26 @@ export function TorlinkStatus(): React.ReactElement {
   const refresh = useCallback(async (): Promise<void> => {
     if (inFlight.current) return;
     inFlight.current = true;
+    // A hung request must never wedge the poller. Without a timeout the fetch
+    // promise can stay pending indefinitely, so `finally` never runs, inFlight
+    // stays true, and every later tick returns early — the page then freezes on
+    // its last snapshot forever, showing a stale timestamp and no error at all.
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), POLL_MS * 3);
     try {
-      const res = await fetch('/api/account/seedbox/status', { cache: 'no-store' });
+      const res = await fetch('/api/account/seedbox/status', {
+        cache: 'no-store',
+        signal: controller.signal,
+      });
       const json = (await res.json().catch(() => ({}))) as StatusResponse;
       setData(json);
       setFetchError(null);
       setUpdatedAt(Date.now());
     } catch (err) {
-      setFetchError(err instanceof Error ? err.message : 'Failed to load status');
+      const aborted = err instanceof Error && /abort/i.test(err.message);
+      setFetchError(aborted ? 'Status request timed out — retrying…' : err instanceof Error ? err.message : 'Failed to load status');
     } finally {
+      clearTimeout(timeout);
       inFlight.current = false;
       setLoading(false);
     }


### PR DESCRIPTION
Follow-up to #142 — the other half of "the Torlink status page is wrong or stale."

#142 fixed **wrong** (torrents hidden by the disk-reconciliation filter). This fixes **stale**.

## The bug

The status poller guards concurrent runs with an `inFlight` ref:

```ts
if (inFlight.current) return;
inFlight.current = true;
try { await fetch('/api/account/seedbox/status', { cache: 'no-store' }) }
finally { inFlight.current = false }
```

The client `fetch` had **no timeout**. A request that *hangs* — rather than failing — leaves that promise pending forever, so `finally` never runs and `inFlight` stays `true`. Every subsequent 3-second tick then hits the guard and returns early.

The page sits on its last snapshot indefinitely: stale torrent list, frozen "updated" timestamp, and **no error shown**, because nothing ever threw. Reported from the live page as an `updated` time stuck hours in the past.

Note the server route already had an 8s `AbortController`; the client had none, which is the gap.

## The fix

Abort the request after 3 poll intervals, so the guard is always released, and surface a timeout distinctly:

```ts
const controller = new AbortController();
const timeout = setTimeout(() => controller.abort(), POLL_MS * 3);
...
finally { clearTimeout(timeout); inFlight.current = false; setLoading(false); }
```

The user now sees "Status request timed out — retrying…" and polling recovers on the next tick, instead of silently frozen numbers.

## Testing

Full suite green (178 files, 2461 passed) via the pre-commit hook; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)