### PR TITLE
feat(seedbox): show torlink's raw counts so a missing torrent is diagnosable

### DIFF
--- a/src/app/api/account/seedbox/status/route.ts
+++ b/src/app/api/account/seedbox/status/route.ts
@@ -124,8 +124,27 @@ export async function GET(): Promise<NextResponse> {
         uploaded: s.uploaded ?? 0,
       }))
       .filter((s) => isLiveTorrent(s.status, s.name, onDisk));
+    // Raw, UNFILTERED counts straight from torlink, plus anything the
+    // reconciliation dropped. Without this the page can only ever show what
+    // survived the filter, so "torlink doesn't have it" and "the app hid it"
+    // look identical — which is exactly the ambiguity that made a missing
+    // torrent impossible to diagnose from the UI.
+    const rawDownloads = data.downloads ?? [];
+    const rawSeeds = data.seeds ?? [];
+    const keptIds = new Set([...downloads, ...seeds].map((t) => t.id));
+    const hidden = [...rawDownloads, ...rawSeeds]
+      .filter((t) => !keptIds.has((t.id ?? '').toLowerCase()))
+      .map((t) => ({ name: t.name ?? '(unknown)', status: t.status ?? '(none)' }));
+
     return NextResponse.json(
-      { configured: true, reachable: true, reconciled: onDisk !== null, downloads, seeds },
+      {
+        configured: true,
+        reachable: true,
+        reconciled: onDisk !== null,
+        downloads,
+        seeds,
+        raw: { downloads: rawDownloads.length, seeds: rawSeeds.length, hidden },
+      },
       { status: 200, headers: NO_STORE }
     );
   } catch (error) {

--- a/src/app/seedboxes/torlink-status.tsx
+++ b/src/app/seedboxes/torlink-status.tsx
@@ -37,6 +37,8 @@ interface StatusResponse {
   error?: string;
   downloads?: RawDownload[];
   seeds?: RawSeed[];
+  /** Unfiltered view of what torlink itself reported, for diagnosing gaps. */
+  raw?: { downloads: number; seeds: number; hidden: { name: string; status: string }[] };
 }
 
 /** A torrent merged from torlink's `downloads` + `seeds` arrays (by infohash). */
@@ -340,6 +342,13 @@ export function TorlinkStatus(): React.ReactElement {
           {updatedAt ? (
             <span>· updated {new Date(updatedAt).toLocaleTimeString()}</span>
           ) : null}
+          {/* What torlink itself reported, before any filtering. Makes "torlink
+              never got it" distinguishable from "the app hid it" at a glance. */}
+          {data?.raw ? (
+            <span title="Raw counts reported by torlink, before reconciliation">
+              · torlink reports {data.raw.downloads + data.raw.seeds} ({data.raw.downloads} dl / {data.raw.seeds} seed)
+            </span>
+          ) : null}
         </div>
         <button
           onClick={() => void refresh()}
@@ -348,6 +357,24 @@ export function TorlinkStatus(): React.ReactElement {
           <RefreshIcon size={14} /> Refresh
         </button>
       </div>
+
+      {/* Anything torlink reported that reconciliation dropped. Should normally
+          be empty; when it isn't, this names exactly what is being hidden. */}
+      {data?.raw?.hidden?.length ? (
+        <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-3 text-xs text-text-secondary">
+          <strong className="text-amber-500">
+            {data.raw.hidden.length} torrent(s) reported by torlink but hidden here
+          </strong>{' '}
+          (their files are not on the seedbox):
+          <ul className="mt-1 list-inside list-disc">
+            {data.raw.hidden.map((h, i) => (
+              <li key={`${h.name}-${i}`}>
+                {h.name} — <span className="text-text-tertiary">{h.status}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
 
       {actionError ? (
         <div className="rounded-lg border border-status-error/40 bg-status-error/5 p-3 text-sm text-status-error">


### PR DESCRIPTION
## Why

A torrent stopped appearing on the Torlink status page. Diagnosing it took shell access to the seedbox and the bearer token, because **the page can only ever show what survived reconciliation**. From the UI, these two look identical:

- torlink never received the torrent
- torlink has it, and the app filtered it out

That ambiguity is what made this take so long to chase. #142 fixed one filtering bug; the page still can't *prove* which case you're in.

## What this adds

The status route now also returns torlink's **unfiltered** counts, plus the name and status of anything reconciliation dropped:

```json
"raw": { "downloads": 2, "seeds": 23, "hidden": [{ "name": "…", "status": "failed" }] }
```

The page shows `· torlink reports 25 (2 dl / 23 seed)` next to the live indicator, and lists any hidden torrents in an amber block naming each one and its status.

## Reading it

| what you see | what it means |
|---|---|
| raw count **equals** the rendered list | torlink genuinely doesn't have it — the add never landed |
| raw count **higher** | the app is hiding it, and the block names exactly which and why |

Either way it's answerable from the browser, with no SSH and no bearer token.

## Testing

Full suite green (178 files, 2461 passed) via the pre-commit hook; `tsc --noEmit` clean; no new lint warnings.

Note: the pre-commit run failed once on `email-accounts-section` / `rss-content` tripping their 5s timeouts under parallel load, then passed on a clean re-run. Those are pre-existing flakes unrelated to this change (flagged back in #139) — their timeouts are tight enough that a growing suite keeps catching them, and they're worth raising separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)