### PR TITLE
fix(tmdb): validate pagination parameters

### DIFF
--- a/src/app/api/recent/movies/route.test.ts
+++ b/src/app/api/recent/movies/route.test.ts
@@ -119,6 +119,23 @@ describe('Recent Movies API - GET /api/recent/movies', () => {
     expect(mockGetRecentMovies).toHaveBeenCalledWith(1);
   });
 
+  it('should use page 1 for a non-integer page parameter', async () => {
+    (getAuthenticatedUser as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ id: 'user-123' });
+
+    mockGetRecentMovies.mockResolvedValueOnce({
+      items: [],
+      page: 1,
+      totalPages: 1,
+      totalResults: 0,
+    });
+
+    const request = new NextRequest('http://localhost/api/recent/movies?page=invalid');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(mockGetRecentMovies).toHaveBeenCalledWith(1);
+  });
+
   it('should set Cache-Control header', async () => {
     (getAuthenticatedUser as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ id: 'user-123' });
 

--- a/src/app/api/recent/movies/route.ts
+++ b/src/app/api/recent/movies/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getAuthenticatedUser } from '@/lib/auth';
+import { parseIntegerParam } from '@/lib/api/pagination';
 import { getTMDBService } from '@/lib/tmdb';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -22,7 +23,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   try {
-    const page = Math.max(1, parseInt(request.nextUrl.searchParams.get('page') ?? '1', 10));
+    const page = parseIntegerParam(request.nextUrl.searchParams.get('page'), { min: 1 }) ?? 1;
     const tmdbService = getTMDBService();
     const result = await tmdbService.getRecentMovies(page);
 

--- a/src/app/api/recent/tvseries/route.test.ts
+++ b/src/app/api/recent/tvseries/route.test.ts
@@ -119,6 +119,23 @@ describe('Recent TV Series API - GET /api/recent/tvseries', () => {
     expect(mockGetRecentTVSeries).toHaveBeenCalledWith(1);
   });
 
+  it('should use page 1 for a non-integer page parameter', async () => {
+    (getAuthenticatedUser as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ id: 'user-123' });
+
+    mockGetRecentTVSeries.mockResolvedValueOnce({
+      items: [],
+      page: 1,
+      totalPages: 1,
+      totalResults: 0,
+    });
+
+    const request = new NextRequest('http://localhost/api/recent/tvseries?page=invalid');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(mockGetRecentTVSeries).toHaveBeenCalledWith(1);
+  });
+
   it('should set Cache-Control header', async () => {
     (getAuthenticatedUser as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ id: 'user-123' });
 

--- a/src/app/api/recent/tvseries/route.ts
+++ b/src/app/api/recent/tvseries/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getAuthenticatedUser } from '@/lib/auth';
+import { parseIntegerParam } from '@/lib/api/pagination';
 import { getTMDBService } from '@/lib/tmdb';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -22,7 +23,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   try {
-    const page = Math.max(1, parseInt(request.nextUrl.searchParams.get('page') ?? '1', 10));
+    const page = parseIntegerParam(request.nextUrl.searchParams.get('page'), { min: 1 }) ?? 1;
     const tmdbService = getTMDBService();
     const result = await tmdbService.getRecentTVSeries(page);
 

--- a/src/app/api/tmdb/search/route.test.ts
+++ b/src/app/api/tmdb/search/route.test.ts
@@ -150,6 +150,23 @@ describe('TMDB Search API - GET /api/tmdb/search', () => {
     expect(mockSearchMulti).toHaveBeenCalledWith('batman', 1);
   });
 
+  it('should use page 1 for a non-integer page parameter', async () => {
+    (getAuthenticatedUser as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ id: 'user-123' });
+
+    mockSearchMulti.mockResolvedValueOnce({
+      items: [],
+      page: 1,
+      totalPages: 1,
+      totalResults: 0,
+    });
+
+    const request = new NextRequest('http://localhost/api/tmdb/search?q=batman&page=invalid');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(mockSearchMulti).toHaveBeenCalledWith('batman', 1);
+  });
+
   it('should trim query whitespace', async () => {
     (getAuthenticatedUser as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ id: 'user-123' });
 

--- a/src/app/api/tmdb/search/route.ts
+++ b/src/app/api/tmdb/search/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getAuthenticatedUser } from '@/lib/auth';
+import { parseIntegerParam } from '@/lib/api/pagination';
 import { getTMDBService } from '@/lib/tmdb';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -30,7 +31,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   try {
-    const page = Math.max(1, parseInt(request.nextUrl.searchParams.get('page') ?? '1', 10));
+    const page = parseIntegerParam(request.nextUrl.searchParams.get('page'), { min: 1 }) ?? 1;
     const tmdbService = getTMDBService();
     const result = await tmdbService.searchMulti(query, page);
 

--- a/src/app/api/upcoming/movies/route.test.ts
+++ b/src/app/api/upcoming/movies/route.test.ts
@@ -120,6 +120,23 @@ describe('Upcoming Movies API - GET /api/upcoming/movies', () => {
     expect(mockGetUpcomingMovies).toHaveBeenCalledWith(1);
   });
 
+  it('should use page 1 for a non-integer page parameter', async () => {
+    (getAuthenticatedUser as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ id: 'user-123' });
+
+    mockGetUpcomingMovies.mockResolvedValueOnce({
+      items: [],
+      page: 1,
+      totalPages: 1,
+      totalResults: 0,
+    });
+
+    const request = new NextRequest('http://localhost/api/upcoming/movies?page=invalid');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(mockGetUpcomingMovies).toHaveBeenCalledWith(1);
+  });
+
   it('should set Cache-Control header', async () => {
     (getAuthenticatedUser as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ id: 'user-123' });
 

--- a/src/app/api/upcoming/movies/route.ts
+++ b/src/app/api/upcoming/movies/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getAuthenticatedUser } from '@/lib/auth';
+import { parseIntegerParam } from '@/lib/api/pagination';
 import { getTMDBService } from '@/lib/tmdb';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -22,7 +23,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   try {
-    const page = Math.max(1, parseInt(request.nextUrl.searchParams.get('page') ?? '1', 10));
+    const page = parseIntegerParam(request.nextUrl.searchParams.get('page'), { min: 1 }) ?? 1;
     const tmdbService = getTMDBService();
     const result = await tmdbService.getUpcomingMovies(page);
 

--- a/src/app/api/upcoming/tvseries/route.test.ts
+++ b/src/app/api/upcoming/tvseries/route.test.ts
@@ -120,6 +120,23 @@ describe('Upcoming TV Series API - GET /api/upcoming/tvseries', () => {
     expect(mockGetUpcomingTVSeries).toHaveBeenCalledWith(1);
   });
 
+  it('should use page 1 for a non-integer page parameter', async () => {
+    (getAuthenticatedUser as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ id: 'user-123' });
+
+    mockGetUpcomingTVSeries.mockResolvedValueOnce({
+      items: [],
+      page: 1,
+      totalPages: 1,
+      totalResults: 0,
+    });
+
+    const request = new NextRequest('http://localhost/api/upcoming/tvseries?page=invalid');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(mockGetUpcomingTVSeries).toHaveBeenCalledWith(1);
+  });
+
   it('should set Cache-Control header', async () => {
     (getAuthenticatedUser as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ id: 'user-123' });
 

--- a/src/app/api/upcoming/tvseries/route.ts
+++ b/src/app/api/upcoming/tvseries/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getAuthenticatedUser } from '@/lib/auth';
+import { parseIntegerParam } from '@/lib/api/pagination';
 import { getTMDBService } from '@/lib/tmdb';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -22,7 +23,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   try {
-    const page = Math.max(1, parseInt(request.nextUrl.searchParams.get('page') ?? '1', 10));
+    const page = parseIntegerParam(request.nextUrl.searchParams.get('page'), { min: 1 }) ?? 1;
     const tmdbService = getTMDBService();
     const result = await tmdbService.getUpcomingTVSeries(page);
 


### PR DESCRIPTION
## Summary

- reuse the existing strict `parseIntegerParam()` helper across all five TMDB-backed list/search routes
- fall back to page 1 for malformed, partial, fractional, zero, negative, or unsafe page values instead of forwarding `NaN` or truncated values
- add a route-level regression for every affected endpoint

## Validation

- 47 focused tests passed across the five routes and the shared pagination helper
- targeted TypeScript compilation passed for all changed route modules
- ESLint passed for all changed files
- `git diff --check` passed

Closes #145