### PR TITLE
fix(seedbox): fail loudly when torlink accepts a torrent then drops it

### DIFF
--- a/src/lib/seedbox/add-verify.test.ts
+++ b/src/lib/seedbox/add-verify.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SeedboxHttpConfig } from './config';
+import { verifyTorrentRegistered } from './add-verify';
+
+const HASH = 'dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c';
+
+const http = {
+  baseUrl: 'http://box.example.com:9161',
+  addPath: '/add',
+  magnetField: 'magnet',
+  token: 'tok',
+  auth: { kind: 'bearer' },
+} as unknown as SeedboxHttpConfig;
+
+/** A fetch stub answering /status with the given torlink payload. */
+function statusFetch(payload: unknown, ok = true): typeof fetch {
+  return vi.fn(async () => ({
+    ok,
+    json: async () => payload,
+  })) as unknown as typeof fetch;
+}
+
+const noSleep = async (): Promise<void> => {};
+
+describe('verifyTorrentRegistered', () => {
+  it('confirms a torrent torlink is actually tracking', async () => {
+    const fetchImpl = statusFetch({ downloads: [{ id: HASH, name: 'Big Buck Bunny' }], seeds: [] });
+    const outcome = await verifyTorrentRegistered(http, HASH, 'Big Buck Bunny', {
+      fetchImpl,
+      sleep: noSleep,
+    });
+    expect(outcome).toBe('registered');
+  });
+
+  it('matches a torrent that finished and moved to seeds', async () => {
+    const fetchImpl = statusFetch({ downloads: [], seeds: [{ id: HASH.toUpperCase(), name: 'X' }] });
+    expect(await verifyTorrentRegistered(http, HASH, 'X', { fetchImpl, sleep: noSleep })).toBe(
+      'registered'
+    );
+  });
+
+  it('reports missing when torlink claimed success but has nothing', async () => {
+    // The production bug: /add answered {"ok":true,"outcome":"added"} and the
+    // torrent never existed. Verification is the only thing that catches it.
+    const fetchImpl = statusFetch({ downloads: [], seeds: [{ id: 'beef', name: 'Unrelated' }] });
+    const outcome = await verifyTorrentRegistered(http, HASH, 'Big Buck Bunny', {
+      fetchImpl,
+      sleep: noSleep,
+      attempts: 3,
+    });
+    expect(outcome).toBe('missing');
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries and succeeds when the torrent shows up late', async () => {
+    let call = 0;
+    const fetchImpl = vi.fn(async () => {
+      call += 1;
+      return {
+        ok: true,
+        json: async () => (call < 3 ? { downloads: [], seeds: [] } : { downloads: [{ id: HASH }] }),
+      };
+    }) as unknown as typeof fetch;
+
+    expect(
+      await verifyTorrentRegistered(http, HASH, 'Late', { fetchImpl, sleep: noSleep, attempts: 4 })
+    ).toBe('registered');
+  });
+
+  it('falls back to a name match before metadata resolves the hash', async () => {
+    const fetchImpl = statusFetch({ downloads: [{ id: '', name: 'Big Buck Bunny' }], seeds: [] });
+    expect(
+      await verifyTorrentRegistered(http, HASH, 'Big Buck Bunny', { fetchImpl, sleep: noSleep })
+    ).toBe('registered');
+  });
+});
+
+describe('verifyTorrentRegistered — never cry wolf', () => {
+  it('is unknown, not missing, when /status cannot be reached', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('connect ECONNREFUSED');
+    }) as unknown as typeof fetch;
+    expect(await verifyTorrentRegistered(http, HASH, 'X', { fetchImpl, sleep: noSleep })).toBe(
+      'unknown'
+    );
+  });
+
+  it('is unknown when /status returns an error code', async () => {
+    const fetchImpl = statusFetch({}, false);
+    expect(await verifyTorrentRegistered(http, HASH, 'X', { fetchImpl, sleep: noSleep })).toBe(
+      'unknown'
+    );
+  });
+
+  it('is unknown when the magnet carries no infohash to match', async () => {
+    const fetchImpl = statusFetch({ downloads: [], seeds: [] });
+    expect(await verifyTorrentRegistered(http, null, 'X', { fetchImpl, sleep: noSleep })).toBe(
+      'unknown'
+    );
+    // No point calling /status when there is nothing to look for.
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('does not burn retries on an unreachable daemon', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('boom');
+    }) as unknown as typeof fetch;
+    await verifyTorrentRegistered(http, HASH, 'X', { fetchImpl, sleep: noSleep, attempts: 5 });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/seedbox/add-verify.ts
+++ b/src/lib/seedbox/add-verify.ts
@@ -1,0 +1,128 @@
+/**
+ * Post-add verification.
+ *
+ * torlink's `/add` answers `200 {"ok":true,"outcome":"added"}` the moment it
+ * accepts a magnet — *before* anything is queued, and without checking that the
+ * queue accepted it. A daemon whose client is wedged (or whose queue never
+ * restarts an item) therefore reports a perfectly healthy "added" for a torrent
+ * it then silently drops on the floor. Observed in production: two magnets came
+ * back `added`, never appeared in `/status`, and never hit disk — the send UI
+ * showed success while nothing happened, which is the worst possible outcome
+ * because there is nothing to retry and nothing to see.
+ *
+ * So a 2xx from `/add` is treated as a *claim*, not a result: we re-read
+ * `/status` and only report success once the torrent is genuinely there.
+ */
+
+import type { SeedboxHttpConfig } from './config';
+import { buildAuthHeaders } from './http-transport';
+
+/**
+ * - `registered` — torlink is tracking it; the add really worked.
+ * - `missing`    — torlink claimed success but does not have it. A real bug.
+ * - `unknown`    — we could not check (status unreachable/unparseable, or no
+ *                  infohash to match on). Callers MUST fail open here: never
+ *                  report a working send as broken on the strength of a failed
+ *                  verification.
+ */
+export type VerifyOutcome = 'registered' | 'missing' | 'unknown';
+
+export interface VerifyOptions {
+  /** How many times to re-read /status before giving up. */
+  attempts?: number;
+  /** Delay between attempts, in ms. */
+  delayMs?: number;
+  fetchImpl?: typeof fetch;
+  /** Injectable for tests so they don't spend real time sleeping. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+interface StatusEntry {
+  id?: string;
+  name?: string;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/** One read of /status. Returns null when it can't be read or parsed. */
+async function readStatusEntries(
+  config: SeedboxHttpConfig,
+  fetchImpl: typeof fetch
+): Promise<StatusEntry[] | null> {
+  const url = `${config.baseUrl.replace(/\/+$/, '')}/status`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 6000);
+  try {
+    const res = await fetchImpl(url, {
+      headers: buildAuthHeaders(config),
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { downloads?: StatusEntry[]; seeds?: StatusEntry[] };
+    const downloads = Array.isArray(json.downloads) ? json.downloads : [];
+    const seeds = Array.isArray(json.seeds) ? json.seeds : [];
+    return [...downloads, ...seeds];
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Whether `/status` lists this torrent. Matching is by infohash (torlink's `id`)
+ * and falls back to an exact name match, because a torrent added from a magnet
+ * can briefly appear under its display name before metadata resolves — and a
+ * false "missing" is worse than a missed detection.
+ */
+function isPresent(entries: StatusEntry[], infohash: string, name: string): boolean {
+  const wantedName = name.trim().toLowerCase();
+  return entries.some((entry) => {
+    if ((entry.id ?? '').toLowerCase() === infohash) return true;
+    return wantedName.length > 0 && (entry.name ?? '').trim().toLowerCase() === wantedName;
+  });
+}
+
+/**
+ * Re-read `/status` until the torrent shows up, or we run out of attempts.
+ *
+ * torlink enqueues synchronously on a healthy daemon, so this normally succeeds
+ * on the first read; the retries exist only to absorb a slow restore on a busy
+ * box. Any inability to check yields `unknown`, never `missing`.
+ */
+export async function verifyTorrentRegistered(
+  config: SeedboxHttpConfig,
+  infohash: string | null,
+  name: string,
+  options: VerifyOptions = {}
+): Promise<VerifyOutcome> {
+  if (!infohash) return 'unknown';
+  const attempts = options.attempts ?? 4;
+  const delayMs = options.delayMs ?? 700;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const sleep = options.sleep ?? defaultSleep;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const entries = await readStatusEntries(config, fetchImpl);
+    // Unreadable status ⇒ we have no evidence either way. Stop immediately
+    // rather than retrying: the verdict would be `unknown` regardless, and
+    // spending seconds re-polling a dead endpoint only delays the send.
+    if (entries === null) return 'unknown';
+    if (isPresent(entries, infohash, name)) return 'registered';
+    if (attempt < attempts - 1) await sleep(delayMs);
+  }
+  // We read the list, repeatedly, and it genuinely isn't there.
+  return 'missing';
+}
+
+/**
+ * The message shown when torlink accepted a magnet but never registered it.
+ * Deliberately specific: the user's instinct is to retry the send, and retrying
+ * will produce the same silent success, so point at the daemon instead.
+ */
+export const ADD_DROPPED_MESSAGE =
+  'Seedbox accepted the torrent but never registered it — the torlink daemon is ' +
+  'wedged and is silently dropping adds. Restart it (Setup → Install torlink & ' +
+  'open ports), then send again.';

--- a/src/lib/seedbox/magnet.test.ts
+++ b/src/lib/seedbox/magnet.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseInfohash } from './magnet';
+
+const HEX = 'dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c';
+// The same 160-bit hash, RFC 4648 base32 — the other legal v1 magnet encoding.
+const BASE32 = '3WBFL3G4PSSV7MF37AJSHWDQMLNR63I4';
+
+describe('parseInfohash', () => {
+  it('reads a hex infohash and normalizes it to lowercase', () => {
+    expect(parseInfohash(`magnet:?xt=urn:btih:${HEX}&dn=Big+Buck+Bunny`)).toBe(HEX);
+    expect(parseInfohash(`magnet:?xt=urn:btih:${HEX.toUpperCase()}`)).toBe(HEX);
+  });
+
+  it('decodes a base32 infohash to the same hex', () => {
+    // torlink keys /status by hex, so a base32 magnet must still be matchable
+    // or every send using one would look like a silent drop.
+    expect(parseInfohash(`magnet:?xt=urn:btih:${BASE32}&dn=Example`)).toBe(HEX);
+    expect(parseInfohash(`magnet:?xt=urn:btih:${BASE32.toLowerCase()}`)).toBe(HEX);
+  });
+
+  it('finds the hash regardless of parameter order', () => {
+    expect(parseInfohash(`magnet:?dn=Example&xt=urn:btih:${HEX}&tr=udp%3A%2F%2Ft`)).toBe(HEX);
+  });
+
+  it('returns null when there is no usable v1 infohash', () => {
+    expect(parseInfohash('magnet:?dn=NoHashHere')).toBeNull();
+    expect(parseInfohash('not a magnet at all')).toBeNull();
+    // Wrong length: neither 40-hex nor 32-base32.
+    expect(parseInfohash('magnet:?xt=urn:btih:abc123')).toBeNull();
+    // v2-only magnets carry btmh, which we cannot match against torlink.
+    expect(parseInfohash('magnet:?xt=urn:btmh:1220caf1e1')).toBeNull();
+  });
+});

--- a/src/lib/seedbox/magnet.ts
+++ b/src/lib/seedbox/magnet.ts
@@ -1,0 +1,44 @@
+/**
+ * Magnet URI parsing.
+ *
+ * torlink keys every torrent in `/status` by its infohash (lowercase hex), so
+ * to confirm an add actually landed we need the infohash of the magnet we sent.
+ */
+
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+/**
+ * Decode a 32-char RFC 4648 base32 btih into 40-char hex.
+ * BitTorrent v1 magnets may carry either encoding of the same 160-bit hash.
+ */
+function base32ToHex(input: string): string | null {
+  let bits = '';
+  for (const char of input.toUpperCase()) {
+    const index = BASE32_ALPHABET.indexOf(char);
+    if (index < 0) return null;
+    bits += index.toString(2).padStart(5, '0');
+  }
+  // 32 base32 chars = 160 bits exactly; anything shorter isn't a v1 infohash.
+  if (bits.length < 160) return null;
+  let hex = '';
+  for (let i = 0; i < 160; i += 4) {
+    hex += parseInt(bits.slice(i, i + 4), 2).toString(16);
+  }
+  return hex;
+}
+
+/**
+ * Extract the v1 infohash from a magnet URI as lowercase hex, or null when the
+ * magnet carries no usable `xt=urn:btih:` (e.g. a v2-only `btmh` magnet).
+ *
+ * Callers treat null as "can't verify" and must fail open rather than reporting
+ * a send as broken just because we couldn't read its hash.
+ */
+export function parseInfohash(magnet: string): string | null {
+  const match = /xt=urn:btih:([a-z0-9]+)/i.exec(magnet);
+  if (!match) return null;
+  const raw = match[1];
+  if (/^[0-9a-f]{40}$/i.test(raw)) return raw.toLowerCase();
+  if (/^[a-z2-7]{32}$/i.test(raw)) return base32ToHex(raw);
+  return null;
+}

--- a/src/lib/seedbox/provision.test.ts
+++ b/src/lib/seedbox/provision.test.ts
@@ -43,13 +43,29 @@ describe('seedbox provisioner', () => {
       expect(script).toContain('not found'); // missing route -> emit controls fail
     });
 
-    it('starts serve and files daemons bound to the token and public host', () => {
-      expect(script).toContain(`serve --host 0.0.0.0 --port "$SERVE_PORT" --token "$TOK"`);
-      expect(script).toContain(`files --host 0.0.0.0 --port "$FILES_PORT" --token "$TOK"`);
+    it('starts serve and files daemons bound to the public host', () => {
+      expect(script).toContain(`serve --host 0.0.0.0 --port "$SERVE_PORT"`);
+      expect(script).toContain(`files --host 0.0.0.0 --port "$FILES_PORT"`);
       expect(script).toContain('--daemon');
       expect(script).toContain("TOK='TOK123_-'");
       expect(script).toContain("SERVE_PORT='9161'");
       expect(script).toContain("FILES_PORT='9160'");
+    });
+
+    it('never puts the bearer token on a command line', () => {
+      // argv is world-readable via `ps`, so `--token <secret>` hands the seedbox
+      // API key to every user on the box. torlink reads
+      // `U.token ?? process.env.TORLINK_API_TOKEN` and refuses to bind a public
+      // interface with no token at all, so the env-var route is both safe and
+      // fail-loud.
+      // Compare executable lines only — a comment mentioning the flag is fine.
+      const code = script
+        .split('\n')
+        .filter((line) => !line.trim().startsWith('#'))
+        .join('\n');
+      expect(code).not.toContain('--token');
+      expect(code).toContain('TORLINK_API_TOKEN=');
+      expect(code).toContain('TORLINK_FILES_TOKEN=');
     });
 
     // Pull out just the `serve ... --daemon` invocation so assertions target the

--- a/src/lib/seedbox/provision.ts
+++ b/src/lib/seedbox/provision.ts
@@ -250,7 +250,12 @@ Environment="PATH=$UNIT_PATH"
 Environment="TORLINK_API_TOKEN=$TOK"
 Environment="TORLINK_FILES_TOKEN=$TOK"
 Environment="TORLINK_MAX_DOWNLOADS=2"
-ExecStart=$BIN serve --host 0.0.0.0 --port $SERVE_PORT --token $TOK --to "$DATA" ${seedFlag}
+# The token comes from the environment above, NOT argv: anything on the command
+# line is world-readable in \`ps\` to every user on the box. torlink reads
+# \`U.token ?? process.env.TORLINK_API_TOKEN\`, and refuses to bind a public
+# interface with no token at all — so a missing env var fails the unit loudly
+# instead of quietly exposing an unauthenticated API.
+ExecStart=$BIN serve --host 0.0.0.0 --port $SERVE_PORT --to "$DATA" ${seedFlag}
 Restart=always
 RestartSec=5
 
@@ -271,7 +276,8 @@ Type=simple
 Environment="PATH=$UNIT_PATH"
 Environment="TORLINK_API_TOKEN=$TOK"
 Environment="TORLINK_FILES_TOKEN=$TOK"
-ExecStart=$BIN files --host 0.0.0.0 --port $FILES_PORT --token $TOK --dir "$DATA"
+# Token via environment, not argv — see the add-API unit above.
+ExecStart=$BIN files --host 0.0.0.0 --port $FILES_PORT --dir "$DATA"
 Restart=always
 RestartSec=5
 
@@ -306,12 +312,16 @@ if [ "$SUPERVISED" = "1" ]; then
     emit files fail "torlink-files.service started but nothing answered on $FILES_PORT — run 'systemctl --user status torlink-files' on the box"
   fi
 else
-  if "$BIN" serve --host 0.0.0.0 --port "$SERVE_PORT" --token "$TOK" --to "$DATA" ${seedFlag}--daemon >/tmp/torlnk-serve.log 2>&1; then
+  # Export rather than pass --token: argv is visible in \`ps\` to every user on
+  # the box, and torlink falls back to these env vars.
+  export TORLINK_API_TOKEN="$TOK"
+  export TORLINK_FILES_TOKEN="$TOK"
+  if "$BIN" serve --host 0.0.0.0 --port "$SERVE_PORT" --to "$DATA" ${seedFlag}--daemon >/tmp/torlnk-serve.log 2>&1; then
     emit serve ok "add-API on $SERVE_PORT (downloads: $DATA; ${seedDesc})"
   else
     emit serve fail "$(tail -n 3 /tmp/torlnk-serve.log 2>/dev/null | tr '\\n' ' ')"
   fi
-  if "$BIN" files --host 0.0.0.0 --port "$FILES_PORT" --token "$TOK" --dir "$DATA" --daemon >/tmp/torlnk-files.log 2>&1; then
+  if "$BIN" files --host 0.0.0.0 --port "$FILES_PORT" --dir "$DATA" --daemon >/tmp/torlnk-files.log 2>&1; then
     emit files ok "file server on $FILES_PORT (serving: $DATA)"
   else
     emit files fail "$(tail -n 3 /tmp/torlnk-files.log 2>/dev/null | tr '\\n' ' ')"
@@ -470,8 +480,8 @@ systemctl --user restart torlink-serve.service torlink-files.service >/dev/null 
 export TORLINK_API_TOKEN="$TOK"
 export TORLINK_FILES_TOKEN="$TOK"
 export TORLINK_MAX_DOWNLOADS=2
-"$BIN" serve --host 0.0.0.0 --port "$SERVE_PORT" --token "$TOK" --to "$DATA" ${seedFlag}--daemon >/dev/null 2>&1 || true
-"$BIN" files --host 0.0.0.0 --port "$FILES_PORT" --token "$TOK" --dir "$DATA" --daemon >/dev/null 2>&1 || true
+"$BIN" serve --host 0.0.0.0 --port "$SERVE_PORT" --to "$DATA" ${seedFlag}--daemon >/dev/null 2>&1 || true
+"$BIN" files --host 0.0.0.0 --port "$FILES_PORT" --dir "$DATA" --daemon >/dev/null 2>&1 || true
 WDEOF
 chmod +x "$WD" 2>/dev/null || true
 WD_MARK="# torlink-watchdog-media-streamer"

--- a/src/lib/seedbox/send.test.ts
+++ b/src/lib/seedbox/send.test.ts
@@ -7,6 +7,7 @@ vi.mock('./ssh-transport', () => ({
 }));
 vi.mock('./http-transport', () => ({
   sendMagnetViaHttp: vi.fn().mockResolvedValue({ ok: true, transport: 'http', message: 'http' }),
+  buildAuthHeaders: vi.fn().mockReturnValue({ Authorization: 'Bearer tok' }),
 }));
 
 import type { SeedboxConfig } from './config';
@@ -79,5 +80,65 @@ describe('sendTorrentToSeedbox — SSH delivery', () => {
     expect(result.ok).toBe(true);
     expect(sendMagnetViaSsh).toHaveBeenCalledTimes(1);
     expect(sendMagnetViaSshToLocalApi).not.toHaveBeenCalled();
+  });
+});
+
+describe('sendTorrentToSeedbox — a silent drop must not report success', () => {
+  const config = { http, ssh: null, files: null } as unknown as SeedboxConfig;
+  const noSleep = async (): Promise<void> => {};
+
+  /** /status answering with the given torrent list. */
+  const statusFetch = (entries: unknown[]): typeof fetch =>
+    vi.fn(async () => ({ ok: true, json: async () => ({ downloads: entries, seeds: [] }) })) as
+      unknown as typeof fetch;
+
+  it('turns torlink’s fake "added" into a real error', async () => {
+    // Observed in production: /add returned {"ok":true,"outcome":"added"} and
+    // the torrent never appeared in /status or on disk. The user saw "Sent"
+    // and lost the torrent. A send that cannot be verified is not a send.
+    const result = await sendTorrentToSeedbox(MAGNET, 'Example', 'http', config, {
+      fetchImpl: statusFetch([]),
+      sleep: noSleep,
+      attempts: 2,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/never registered it/i);
+  });
+
+  it('reports success when torlink really did take it', async () => {
+    const result = await sendTorrentToSeedbox(MAGNET, 'Example', 'http', config, {
+      fetchImpl: statusFetch([{ id: '0123456789abcdef0123456789abcdef01234567' }]),
+      sleep: noSleep,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toBe('http');
+  });
+
+  it('fails open when /status cannot be read, rather than inventing a failure', async () => {
+    const dead = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof fetch;
+
+    const result = await sendTorrentToSeedbox(MAGNET, 'Example', 'http', config, {
+      fetchImpl: dead,
+      sleep: noSleep,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('never overrides a transport error with the verification message', async () => {
+    const { sendMagnetViaHttp } = await import('./http-transport');
+    (sendMagnetViaHttp as unknown as { mockResolvedValueOnce: (v: unknown) => void })
+      .mockResolvedValueOnce({ ok: false, transport: 'http', message: 'Seedbox API returned 401' });
+
+    const result = await sendTorrentToSeedbox(MAGNET, 'Example', 'http', config, {
+      fetchImpl: statusFetch([]),
+      sleep: noSleep,
+    });
+
+    expect(result.message).toBe('Seedbox API returned 401');
   });
 });

--- a/src/lib/seedbox/send.ts
+++ b/src/lib/seedbox/send.ts
@@ -9,6 +9,8 @@ import {
 } from './config';
 import { sendMagnetViaHttp, type SendResult } from './http-transport';
 import { getSeedboxPublicKey, sendMagnetViaSsh, sendMagnetViaSshToLocalApi } from './ssh-transport';
+import { ADD_DROPPED_MESSAGE, verifyTorrentRegistered, type VerifyOptions } from './add-verify';
+import { parseInfohash } from './magnet';
 
 export interface SeedboxAccess {
   /** True when this account may push to a configured seedbox transport. */
@@ -50,6 +52,29 @@ export function isValidMagnet(magnet: unknown): magnet is string {
  * configured one when `transport` is omitted).
  */
 export async function sendTorrentToSeedbox(
+  magnet: string,
+  name: string,
+  transport: SeedboxTransport | undefined,
+  config: SeedboxConfig,
+  verifyOptions: VerifyOptions = {}
+): Promise<SendResult> {
+  const result = await dispatchSend(magnet, name, transport, config);
+  // A transport reporting success only means the daemon *accepted* the magnet.
+  // torlink answers `added` before it queues anything and will happily drop the
+  // torrent afterwards, so confirm it against /status before telling the user
+  // it worked. Anything short of proof-of-absence leaves the result untouched.
+  if (!result.ok || !config.http) return result;
+  const outcome = await verifyTorrentRegistered(
+    config.http,
+    parseInfohash(magnet),
+    name,
+    verifyOptions
+  );
+  if (outcome !== 'missing') return result;
+  return { ok: false, transport: result.transport, message: ADD_DROPPED_MESSAGE };
+}
+
+async function dispatchSend(
   magnet: string,
   name: string,
   transport: SeedboxTransport | undefined,


### PR DESCRIPTION
## The bug

torlink's `/add` answers `200 {"ok":true,"outcome":"added"}` the moment it accepts a magnet — **before anything is queued**, and without checking that the queue took it. A daemon whose client is wedged reports a perfectly healthy `added` for a torrent it then silently drops.

Reproduced against the live seedbox:

```
POST /add  ->  {"ok":true,"outcome":"added"}   [http 200]
GET /status ->  63 torrents before, 63 after   # never arrived
```

Two real torrents (Pluribus, Cape Fear) were lost exactly this way. The UI showed **"Sent"** while nothing happened — the worst possible outcome, because there is nothing to retry and nothing to see.

## The fix

A 2xx from `/add` is now a **claim, not a result**. The dispatcher re-reads `/status` and only reports success once the torrent is genuinely there. Applies to both the HTTP and SSH transports, since both hand off to the same daemon.

When torlink drops it, the user finally gets a real error instead of a fake success:

> Seedbox accepted the torrent but never registered it — the torlink daemon is wedged and is silently dropping adds. Restart it (Setup → Install torlink & open ports), then send again.

## Verification never cries wolf

A false "your send failed" is its own bug, so proof-of-absence is required before reporting one:

| Situation | Verdict | Result shown |
|---|---|---|
| Torrent in `/status` | `registered` | success (unchanged) |
| Read the list repeatedly, torrent absent | `missing` | **error** |
| `/status` unreachable / non-2xx / unparseable | `unknown` | success (fail open) |
| Magnet has no v1 infohash (e.g. v2-only `btmh`) | `unknown` | success (fail open) |

A transport-level failure is never overwritten by the verification message. An unreadable `/status` stops immediately rather than burning retries, since the verdict would be `unknown` either way.

Matching is by infohash (`parseInfohash` handles both hex and base32 encodings), falling back to an exact name match for the window before metadata resolves.

## Also: stop leaking the bearer token via `ps`

The provisioner passed `--token <secret>` on the command line, and **argv is world-readable**. On the live box:

```
ubuntu 23086 ... torlnk serve --host 0.0.0.0 --port 9161 --token <REDACTED> ...
```

That handed the seedbox API key to every user on the machine. The token now travels only in the unit's environment.

This is safe rather than a way to accidentally open the API: torlink reads `U.token ?? process.env.TORLINK_API_TOKEN` and **refuses to bind a public interface with no token at all**, so a missing env var fails the unit loudly instead of quietly serving an unauthenticated API. Verified against the 1.4.4 bundle.

> **Note for @chovy:** the token visible in that `ps` output should be rotated — re-run Setup to regenerate it.

## Tests

`src/lib/seedbox/magnet.test.ts`, `src/lib/seedbox/add-verify.test.ts`, plus new cases in `send.test.ts` and `provision.test.ts` (asserting no token reaches argv, comparing executable lines so a comment mentioning the flag doesn't pass vacuously).

Full suite: **180 files, 2484 passed**, clean `tsc --noEmit`.

## What this does not fix

The seedbox daemon itself is still wedged — it has been running since Jul 30 with `--seed-time 2h`, which is why all 63 torrents sit `paused` and why the reinstall (with seed time 0) never took effect: the old process was never replaced. This PR makes that condition **visible and actionable** instead of silent; restarting the daemon is still required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)