### PR TITLE
fix(seedbox): pin uint8-util so installing torlink stops crashing the daemon

### DIFF
--- a/src/lib/seedbox/add-verify.ts
+++ b/src/lib/seedbox/add-verify.ts
@@ -120,14 +120,15 @@ export async function verifyTorrentRegistered(
 /**
  * The message shown when torlink accepted a magnet but never registered it.
  *
- * Deliberately specific, and deliberately NOT "restart the daemon": torlink
- * reloads the very queue.json that causes this on every start, so a plain
- * restart reproduces the wedge instead of clearing it. The installer is what
- * fixes it — it moves the unrestartable records aside before starting the
- * daemons — so point there, and say why retrying the send cannot help.
+ * The known cause is not a "wedged" daemon but a crashing one: torlink answers
+ * `/add` with 200, starts fetching metadata, and then dies on an uncaught
+ * TypeError from a bad transitive `uint8-util` release. systemd restarts it and
+ * the in-memory queue goes with it, so the torrent simply disappears. The
+ * installer now pins the working version, which is why this points there — and
+ * why it says retrying is pointless, since a retry just crashes it again.
  */
 export const ADD_DROPPED_MESSAGE =
-  'Seedbox accepted the torrent but never registered it — torlink is holding a ' +
-  'stale queue record it cannot restart, so it silently ignores new adds for ' +
-  'this torrent. Sending again will not help. Re-run Setup → Install torlink & ' +
-  'open ports, which clears those records, then send again.';
+  'Seedbox accepted the torrent but never registered it — the torlink daemon ' +
+  'crashed while reading the torrent and lost it on restart. Sending again will ' +
+  'not help. Re-run Setup → Install torlink & open ports, which pins the fixed ' +
+  'dependency, then send again.';

--- a/src/lib/seedbox/add-verify.ts
+++ b/src/lib/seedbox/add-verify.ts
@@ -119,10 +119,15 @@ export async function verifyTorrentRegistered(
 
 /**
  * The message shown when torlink accepted a magnet but never registered it.
- * Deliberately specific: the user's instinct is to retry the send, and retrying
- * will produce the same silent success, so point at the daemon instead.
+ *
+ * Deliberately specific, and deliberately NOT "restart the daemon": torlink
+ * reloads the very queue.json that causes this on every start, so a plain
+ * restart reproduces the wedge instead of clearing it. The installer is what
+ * fixes it — it moves the unrestartable records aside before starting the
+ * daemons — so point there, and say why retrying the send cannot help.
  */
 export const ADD_DROPPED_MESSAGE =
-  'Seedbox accepted the torrent but never registered it — the torlink daemon is ' +
-  'wedged and is silently dropping adds. Restart it (Setup → Install torlink & ' +
-  'open ports), then send again.';
+  'Seedbox accepted the torrent but never registered it — torlink is holding a ' +
+  'stale queue record it cannot restart, so it silently ignores new adds for ' +
+  'this torrent. Sending again will not help. Re-run Setup → Install torlink & ' +
+  'open ports, which clears those records, then send again.';

--- a/src/lib/seedbox/provision.test.ts
+++ b/src/lib/seedbox/provision.test.ts
@@ -24,7 +24,7 @@ describe('seedbox provisioner', () => {
     it('installs the torlink fork (with the concurrency cap) and enforces Node >= 22', () => {
       expect(script).toContain('npm i -g "$PKG@latest"'); // @latest so a cached global actually upgrades
       expect(script).toContain("PKG='@profullstack/torlink'");
-      expect(script).toContain('TORLINK_MAX_DOWNLOADS=2');
+      expect(script).toContain('TORLINK_MAX_DOWNLOADS=0');
       expect(script).toContain('-lt 22');
     });
 
@@ -231,5 +231,45 @@ describe('seedbox provisioner — install must leave a daemon that stays up', ()
   it('still does not create a watch dir (nothing reads it)', () => {
     expect(script).not.toContain('mkdir -p "$WATCH"');
     expect(script).not.toContain('WATCH="$HOME/Downloads/watch"\nmkdir');
+  });
+});
+
+describe('seedbox provisioner — torlink drops adds when queue.json holds dead records', () => {
+  const script = buildProvisionScript('TOK123_-', DEFAULT_SERVE_PORT, DEFAULT_FILES_PORT);
+
+  it('leaves the concurrency cap off', () => {
+    // torlink only calls startEngine() when under the cap; items restored from
+    // queue.json keep a "downloading" status but never get an engine, so they
+    // hold a slot that can never free (promote() fires only on complete/error).
+    // At 2, two such records parked every later add as "queued" forever.
+    expect(script).toContain('TORLINK_MAX_DOWNLOADS=0');
+    expect(script).not.toContain('TORLINK_MAX_DOWNLOADS=2');
+    // Every place the daemons get their environment must agree.
+    expect(script.match(/TORLINK_MAX_DOWNLOADS=0/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('moves unrestartable queue records aside before starting the daemons', () => {
+    expect(script).toContain('emit queue ok');
+    expect(script).toContain('queue.json');
+    expect(script).toContain('.stale');
+    // Backup, never delete — the operator may want to inspect it.
+    expect(script).toContain('mv "$QUEUE_JSON" "$QUEUE_JSON.stale"');
+    expect(script).not.toContain('rm -f "$QUEUE_JSON"');
+  });
+
+  it('clears the queue only after every daemon is dead, so nothing is live', () => {
+    // Clearing while serve is running would race torlink's own persist().
+    const stop = script.indexOf('stop_torlink\n');
+    const clear = script.indexOf('QUEUE_JSON=');
+    const start = script.indexOf('--- start the daemons UNDER SUPERVISION ---');
+    expect(stop).toBeGreaterThan(-1);
+    expect(clear).toBeGreaterThan(stop);
+    expect(clear).toBeLessThan(start);
+  });
+
+  it('counts only records torlink would refuse to re-add', () => {
+    // add() early-returns for any existing record that is not "failed", so a
+    // "failed" one is harmless — it does not need clearing.
+    expect(script).toContain('i.status!=="failed"');
   });
 });

--- a/src/lib/seedbox/provision.test.ts
+++ b/src/lib/seedbox/provision.test.ts
@@ -24,7 +24,7 @@ describe('seedbox provisioner', () => {
     it('installs the torlink fork (with the concurrency cap) and enforces Node >= 22', () => {
       expect(script).toContain('npm i -g "$PKG@latest"'); // @latest so a cached global actually upgrades
       expect(script).toContain("PKG='@profullstack/torlink'");
-      expect(script).toContain('TORLINK_MAX_DOWNLOADS=0');
+      expect(script).toContain('TORLINK_MAX_DOWNLOADS=2');
       expect(script).toContain('-lt 22');
     });
 
@@ -155,6 +155,31 @@ describe('seedbox provisioner', () => {
     it('health-checks the add-API', () => {
       expect(script).toContain('/health');
     });
+
+    it('pins uint8-util, whose 2.3.x release crashes the daemon on every magnet', () => {
+      // uint8-util 2.3.x broke arr2hex. It arrives transitively through
+      // webtorrent on a caret range, so `npm i -g` re-fetches it on every
+      // install — torlink then 200s the add and dies mid-metadata, taking the
+      // in-memory queue with it. Upstream pins 2.2.6; so do we, until the fork
+      // ships a release carrying that pin.
+      expect(script).toContain('UINT8_PIN=2.2.6');
+      expect(script).toContain('uint8-util@$UINT8_PIN');
+      expect(script).toContain('emit uint8 ok');
+      expect(script).toContain('emit uint8 fail');
+    });
+
+    it('pins uint8-util only after the package root is known', () => {
+      // The script runs under `set -u`; referencing $PKG_ROOT before it is
+      // assigned would abort the whole provision.
+      expect(script.indexOf('PKG_ROOT=')).toBeLessThan(script.indexOf('UINT8_PIN='));
+      // And after the install, or there would be nothing to pin into.
+      expect(script.indexOf('npm i -g "$PKG@latest"')).toBeLessThan(script.indexOf('UINT8_PIN='));
+    });
+
+    it('re-pinning is a no-op when the good version is already there', () => {
+      expect(script).toContain('emit uint8 skip');
+      expect(script).toContain('"$UINT8_HAVE" = "$UINT8_PIN"');
+    });
   });
 
   describe('parseSteps', () => {
@@ -231,45 +256,5 @@ describe('seedbox provisioner — install must leave a daemon that stays up', ()
   it('still does not create a watch dir (nothing reads it)', () => {
     expect(script).not.toContain('mkdir -p "$WATCH"');
     expect(script).not.toContain('WATCH="$HOME/Downloads/watch"\nmkdir');
-  });
-});
-
-describe('seedbox provisioner — torlink drops adds when queue.json holds dead records', () => {
-  const script = buildProvisionScript('TOK123_-', DEFAULT_SERVE_PORT, DEFAULT_FILES_PORT);
-
-  it('leaves the concurrency cap off', () => {
-    // promote() only starts a queued item while activeCount < maxDownloads, and
-    // activeCount counts anything marked "downloading". A stalled torrent keeps
-    // that status forever — it never completes and never errors — so its slot
-    // never frees. At 2, two of them parked every later add as "queued" forever.
-    expect(script).toContain('TORLINK_MAX_DOWNLOADS=0');
-    expect(script).not.toContain('TORLINK_MAX_DOWNLOADS=2');
-    // Every place the daemons get their environment must agree.
-    expect(script.match(/TORLINK_MAX_DOWNLOADS=0/g)?.length).toBeGreaterThanOrEqual(3);
-  });
-
-  it('moves unrestartable queue records aside before starting the daemons', () => {
-    expect(script).toContain('emit queue ok');
-    expect(script).toContain('queue.json');
-    expect(script).toContain('.stale');
-    // Backup, never delete — the operator may want to inspect it.
-    expect(script).toContain('mv "$QUEUE_JSON" "$QUEUE_JSON.stale"');
-    expect(script).not.toContain('rm -f "$QUEUE_JSON"');
-  });
-
-  it('clears the queue only after every daemon is dead, so nothing is live', () => {
-    // Clearing while serve is running would race torlink's own persist().
-    const stop = script.indexOf('stop_torlink\n');
-    const clear = script.indexOf('QUEUE_JSON=');
-    const start = script.indexOf('--- start the daemons UNDER SUPERVISION ---');
-    expect(stop).toBeGreaterThan(-1);
-    expect(clear).toBeGreaterThan(stop);
-    expect(clear).toBeLessThan(start);
-  });
-
-  it('counts only records torlink would refuse to re-add', () => {
-    // add() early-returns for any existing record that is not "failed", so a
-    // "failed" one is harmless — it does not need clearing.
-    expect(script).toContain('i.status!=="failed"');
   });
 });

--- a/src/lib/seedbox/provision.test.ts
+++ b/src/lib/seedbox/provision.test.ts
@@ -238,10 +238,10 @@ describe('seedbox provisioner — torlink drops adds when queue.json holds dead 
   const script = buildProvisionScript('TOK123_-', DEFAULT_SERVE_PORT, DEFAULT_FILES_PORT);
 
   it('leaves the concurrency cap off', () => {
-    // torlink only calls startEngine() when under the cap; items restored from
-    // queue.json keep a "downloading" status but never get an engine, so they
-    // hold a slot that can never free (promote() fires only on complete/error).
-    // At 2, two such records parked every later add as "queued" forever.
+    // promote() only starts a queued item while activeCount < maxDownloads, and
+    // activeCount counts anything marked "downloading". A stalled torrent keeps
+    // that status forever — it never completes and never errors — so its slot
+    // never frees. At 2, two of them parked every later add as "queued" forever.
     expect(script).toContain('TORLINK_MAX_DOWNLOADS=0');
     expect(script).not.toContain('TORLINK_MAX_DOWNLOADS=2');
     // Every place the daemons get their environment must agree.

--- a/src/lib/seedbox/provision.ts
+++ b/src/lib/seedbox/provision.ts
@@ -215,12 +215,54 @@ sleep 2
 free_port -KILL "$SERVE_PORT"; free_port -KILL "$FILES_PORT"
 sleep 1
 
+# --- clear queue records torlink can never restart ---
+# torlink restores queue.json into memory at boot but never re-attaches the
+# webtorrent engine to those items. Anything left at "downloading"/"queued" is
+# therefore dead: it makes no progress, still counts toward the concurrency cap,
+# and makes add() a silent no-op for that infohash forever (add() returns early
+# whenever it already holds a non-"failed" record, while /add still answers 200).
+# That is what made a send report success and then never appear anywhere.
+#
+# Nothing is running at this point — stop_torlink above killed every daemon — so
+# any surviving entry is stale by definition. Move the file aside rather than
+# delete it, and let torlink rebuild from a clean slate. Without this, a wedged
+# box stayed wedged across reinstalls and there was no way back short of ssh.
+QUEUE_JSON=$(find "$HOME/.local/share" "$HOME/.config" "$HOME/.local/state" -maxdepth 5 -name queue.json -path '*torl*' 2>/dev/null | head -n 1)
+if [ -n "$QUEUE_JSON" ] && [ -s "$QUEUE_JSON" ]; then
+  STALE=0
+  STALE=$(node -e 'try{const q=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));const a=Array.isArray(q)?q:[];process.stdout.write(String(a.filter(i=>i&&i.status!=="failed").length))}catch(e){process.stdout.write("0")}' "$QUEUE_JSON" 2>/dev/null || echo 0)
+  if [ "$STALE" -gt 0 ] 2>/dev/null; then
+    mv "$QUEUE_JSON" "$QUEUE_JSON.stale" 2>/dev/null || true
+    emit queue ok "cleared $STALE unrestartable queue record(s); backup at $QUEUE_JSON.stale"
+  else
+    emit queue skip "queue.json holds nothing stale"
+  fi
+else
+  emit queue skip "no torlink queue file on this box yet"
+fi
+
 export TORLINK_API_TOKEN="$TOK"
 export TORLINK_FILES_TOKEN="$TOK"
-# Cap concurrent downloads so each active torrent gets fair bandwidth on a
-# limited seedbox line (torlink >= the version with TORLINK_MAX_DOWNLOADS;
-# harmlessly ignored by older builds).
-export TORLINK_MAX_DOWNLOADS=2
+# Concurrency cap: DISABLED (0 = unlimited). This used to be 2, for fair
+# bandwidth on a thin seedbox line. It has to stay off until torlink is fixed.
+#
+# torlink 1.4.4 only starts a torrent's engine when it is under the cap:
+# \`startEngine\` runs from add() when activeCount < maxDownloads, and otherwise
+# only from promote(), which fires when an active download completes or errors.
+# But items restored from queue.json at boot are put back with their old
+# "downloading" status and their engine is NEVER re-attached. Such a record can
+# therefore never complete or error, so promote() never runs, and it occupies a
+# slot forever. At a cap of 2, two of them wedged the box permanently — every
+# later add was parked as "queued" and never started. It survived reinstalls
+# because nothing cleared queue.json (see the step above, which now does).
+#
+# add() compounds it: it returns silently when it already holds a record for
+# that infohash, while /add still answers 200 — so the app reported a successful
+# send for a torrent that went nowhere.
+#
+# With 0, add() always starts the engine, so a stale record cannot block new
+# torrents. Restore the cap once torlink re-attaches restored items to a client.
+export TORLINK_MAX_DOWNLOADS=0
 
 # --- start the daemons UNDER SUPERVISION ---
 # A bare \`--daemon\` process answers to nobody: a crash, an OOM kill or a reboot
@@ -249,7 +291,7 @@ Type=simple
 Environment="PATH=$UNIT_PATH"
 Environment="TORLINK_API_TOKEN=$TOK"
 Environment="TORLINK_FILES_TOKEN=$TOK"
-Environment="TORLINK_MAX_DOWNLOADS=2"
+Environment="TORLINK_MAX_DOWNLOADS=0"
 # The token comes from the environment above, NOT argv: anything on the command
 # line is world-readable in \`ps\` to every user on the box. torlink reads
 # \`U.token ?? process.env.TORLINK_API_TOKEN\`, and refuses to bind a public
@@ -479,7 +521,7 @@ systemctl --user reset-failed torlink-serve.service torlink-files.service >/dev/
 systemctl --user restart torlink-serve.service torlink-files.service >/dev/null 2>&1 && exit 0
 export TORLINK_API_TOKEN="$TOK"
 export TORLINK_FILES_TOKEN="$TOK"
-export TORLINK_MAX_DOWNLOADS=2
+export TORLINK_MAX_DOWNLOADS=0
 "$BIN" serve --host 0.0.0.0 --port "$SERVE_PORT" --to "$DATA" ${seedFlag}--daemon >/dev/null 2>&1 || true
 "$BIN" files --host 0.0.0.0 --port "$FILES_PORT" --dir "$DATA" --daemon >/dev/null 2>&1 || true
 WDEOF

--- a/src/lib/seedbox/provision.ts
+++ b/src/lib/seedbox/provision.ts
@@ -132,6 +132,39 @@ command -v mise >/dev/null 2>&1 && mise reshim >/dev/null 2>&1 || true
 # without torrent controls" trap. Run the freshly-installed dist directly.
 PKG_ROOT="$(npm root -g 2>/dev/null)/@profullstack/torlink"
 CLI_JS="$PKG_ROOT/dist/cli.cjs"
+
+# --- pin uint8-util, which crashes the daemon on every magnet ---
+# uint8-util 2.3.x restructured the package and broke arr2hex. It is a
+# TRANSITIVE dep of webtorrent on a caret range, so \`npm i -g\` silently
+# resolves it to the broken release. The failure is brutal: torlink accepts the
+# magnet (POST /add -> 200), starts fetching metadata, and then throws an
+# UNCAUGHT TypeError inside webtorrent's parse path —
+#
+#   TypeError: The first argument must be of type string or ... Received undefined
+#     at arr2hex (uint8-util/dist/src/node.js:12)
+#     at Torrent._processParsedTorrent (webtorrent/lib/torrent.js:330)
+#
+# — which kills the whole process. systemd restarts it, the in-memory queue is
+# gone with it, and the torrent has vanished. The app sees a 200 from /add and
+# then never finds the torrent in /status. Observed on a live box: 28 crashes,
+# one per send, with an empty queue.json throughout.
+#
+# Reinstalling never helped because the reinstall is what re-fetched the broken
+# version. Upstream fixed this by pinning 2.2.6 (baairon/torlink 5293408); we
+# apply the same pin here so the installer stops re-introducing the crash.
+# Remove once the fork ships a release carrying that pin.
+UINT8_PIN=2.2.6
+if [ -d "$PKG_ROOT" ]; then
+  UINT8_HAVE=$(node -p "require('$PKG_ROOT/node_modules/uint8-util/package.json').version" 2>/dev/null || echo none)
+  if [ "$UINT8_HAVE" = "$UINT8_PIN" ]; then
+    emit uint8 skip "uint8-util already pinned at $UINT8_PIN"
+  elif (cd "$PKG_ROOT" && npm i "uint8-util@$UINT8_PIN" --no-save --silent >/tmp/torlnk-uint8.log 2>&1) \
+    || (command -v sudo >/dev/null 2>&1 && cd "$PKG_ROOT" && sudo -n npm i "uint8-util@$UINT8_PIN" --no-save --silent >>/tmp/torlnk-uint8.log 2>&1); then
+    emit uint8 ok "pinned uint8-util $UINT8_HAVE -> $UINT8_PIN (2.3.x crashes the daemon on every magnet)"
+  else
+    emit uint8 fail "could not pin uint8-util@$UINT8_PIN — the daemon will crash on each add: $(tail -n 2 /tmp/torlnk-uint8.log 2>/dev/null | tr '\\n' ' ')"
+  fi
+fi
 # Neutralize a shadowing wrapper so interactive \`torlnk\` also gets the fresh build
 # (harmless if it doesn't exist).
 if [ -f "$HOME/.local/bin/torlnk" ] && ! grep -q "$PKG_ROOT" "$HOME/.local/bin/torlnk" 2>/dev/null; then
@@ -215,56 +248,12 @@ sleep 2
 free_port -KILL "$SERVE_PORT"; free_port -KILL "$FILES_PORT"
 sleep 1
 
-# --- clear queue records torlink can never restart ---
-# torlink restores queue.json into memory at boot but never re-attaches the
-# webtorrent engine to those items. Anything left at "downloading"/"queued" is
-# therefore dead: it makes no progress, still counts toward the concurrency cap,
-# and makes add() a silent no-op for that infohash forever (add() returns early
-# whenever it already holds a non-"failed" record, while /add still answers 200).
-# That is what made a send report success and then never appear anywhere.
-#
-# Nothing is running at this point — stop_torlink above killed every daemon — so
-# any surviving entry is stale by definition. Move the file aside rather than
-# delete it, and let torlink rebuild from a clean slate. Without this, a wedged
-# box stayed wedged across reinstalls and there was no way back short of ssh.
-QUEUE_JSON=$(find "$HOME/.local/share" "$HOME/.config" "$HOME/.local/state" -maxdepth 5 -name queue.json -path '*torl*' 2>/dev/null | head -n 1)
-if [ -n "$QUEUE_JSON" ] && [ -s "$QUEUE_JSON" ]; then
-  STALE=0
-  STALE=$(node -e 'try{const q=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));const a=Array.isArray(q)?q:[];process.stdout.write(String(a.filter(i=>i&&i.status!=="failed").length))}catch(e){process.stdout.write("0")}' "$QUEUE_JSON" 2>/dev/null || echo 0)
-  if [ "$STALE" -gt 0 ] 2>/dev/null; then
-    mv "$QUEUE_JSON" "$QUEUE_JSON.stale" 2>/dev/null || true
-    emit queue ok "cleared $STALE unrestartable queue record(s); backup at $QUEUE_JSON.stale"
-  else
-    emit queue skip "queue.json holds nothing stale"
-  fi
-else
-  emit queue skip "no torlink queue file on this box yet"
-fi
-
 export TORLINK_API_TOKEN="$TOK"
 export TORLINK_FILES_TOKEN="$TOK"
-# Concurrency cap: DISABLED (0 = unlimited). This used to be 2, for fair
-# bandwidth on a thin seedbox line. It has to stay off until torlink is fixed.
-#
-# torlink's activeCount counts items whose status is "downloading", and
-# promote() only starts a queued item while activeCount < maxDownloads. A
-# stalled download — a dead magnet that never finds a peer — keeps that status
-# forever: it never completes and never errors, so nothing ever frees its slot.
-# At a cap of 2, two such torrents parked every later add as "queued"
-# indefinitely, and the box looked healthy the whole time.
-#
-# add() compounds it: it returns early for any record it already holds that is
-# not "failed", while /add still answers 200. Re-sending the same magnet is
-# therefore a guaranteed silent no-op — the app reported a successful send for
-# a torrent that went nowhere, and retrying could never help.
-#
-# queue.json persists all of this, so the wedge survived daemon restarts and
-# reinstalls alike (see the step above, which now clears it).
-#
-# With 0, promote() short-circuits and add() always starts the engine, so a
-# stalled torrent can no longer block new ones. Restore the cap once torlink
-# can free a slot held by a download that will never progress.
-export TORLINK_MAX_DOWNLOADS=0
+# Cap concurrent downloads so each active torrent gets fair bandwidth on a
+# limited seedbox line (torlink >= the version with TORLINK_MAX_DOWNLOADS;
+# harmlessly ignored by older builds).
+export TORLINK_MAX_DOWNLOADS=2
 
 # --- start the daemons UNDER SUPERVISION ---
 # A bare \`--daemon\` process answers to nobody: a crash, an OOM kill or a reboot
@@ -293,7 +282,7 @@ Type=simple
 Environment="PATH=$UNIT_PATH"
 Environment="TORLINK_API_TOKEN=$TOK"
 Environment="TORLINK_FILES_TOKEN=$TOK"
-Environment="TORLINK_MAX_DOWNLOADS=0"
+Environment="TORLINK_MAX_DOWNLOADS=2"
 # The token comes from the environment above, NOT argv: anything on the command
 # line is world-readable in \`ps\` to every user on the box. torlink reads
 # \`U.token ?? process.env.TORLINK_API_TOKEN\`, and refuses to bind a public
@@ -523,7 +512,7 @@ systemctl --user reset-failed torlink-serve.service torlink-files.service >/dev/
 systemctl --user restart torlink-serve.service torlink-files.service >/dev/null 2>&1 && exit 0
 export TORLINK_API_TOKEN="$TOK"
 export TORLINK_FILES_TOKEN="$TOK"
-export TORLINK_MAX_DOWNLOADS=0
+export TORLINK_MAX_DOWNLOADS=2
 "$BIN" serve --host 0.0.0.0 --port "$SERVE_PORT" --to "$DATA" ${seedFlag}--daemon >/dev/null 2>&1 || true
 "$BIN" files --host 0.0.0.0 --port "$FILES_PORT" --dir "$DATA" --daemon >/dev/null 2>&1 || true
 WDEOF

--- a/src/lib/seedbox/provision.ts
+++ b/src/lib/seedbox/provision.ts
@@ -246,22 +246,24 @@ export TORLINK_FILES_TOKEN="$TOK"
 # Concurrency cap: DISABLED (0 = unlimited). This used to be 2, for fair
 # bandwidth on a thin seedbox line. It has to stay off until torlink is fixed.
 #
-# torlink 1.4.4 only starts a torrent's engine when it is under the cap:
-# \`startEngine\` runs from add() when activeCount < maxDownloads, and otherwise
-# only from promote(), which fires when an active download completes or errors.
-# But items restored from queue.json at boot are put back with their old
-# "downloading" status and their engine is NEVER re-attached. Such a record can
-# therefore never complete or error, so promote() never runs, and it occupies a
-# slot forever. At a cap of 2, two of them wedged the box permanently — every
-# later add was parked as "queued" and never started. It survived reinstalls
-# because nothing cleared queue.json (see the step above, which now does).
+# torlink's activeCount counts items whose status is "downloading", and
+# promote() only starts a queued item while activeCount < maxDownloads. A
+# stalled download — a dead magnet that never finds a peer — keeps that status
+# forever: it never completes and never errors, so nothing ever frees its slot.
+# At a cap of 2, two such torrents parked every later add as "queued"
+# indefinitely, and the box looked healthy the whole time.
 #
-# add() compounds it: it returns silently when it already holds a record for
-# that infohash, while /add still answers 200 — so the app reported a successful
-# send for a torrent that went nowhere.
+# add() compounds it: it returns early for any record it already holds that is
+# not "failed", while /add still answers 200. Re-sending the same magnet is
+# therefore a guaranteed silent no-op — the app reported a successful send for
+# a torrent that went nowhere, and retrying could never help.
 #
-# With 0, add() always starts the engine, so a stale record cannot block new
-# torrents. Restore the cap once torlink re-attaches restored items to a client.
+# queue.json persists all of this, so the wedge survived daemon restarts and
+# reinstalls alike (see the step above, which now clears it).
+#
+# With 0, promote() short-circuits and add() always starts the engine, so a
+# stalled torrent can no longer block new ones. Restore the cap once torlink
+# can free a slot held by a download that will never progress.
 export TORLINK_MAX_DOWNLOADS=0
 
 # --- start the daemons UNDER SUPERVISION ---


### PR DESCRIPTION
Sends returned success and the torrent never appeared. Root-caused on the live box.

## ⚠️ This PR previously described a different (wrong) cause

Earlier revisions blamed stale `queue.json` records and the `TORLINK_MAX_DOWNLOADS` cap. **Both were wrong** — on the affected box `queue.json` is 2 bytes and `/status` reported `downloads: []`, so there were no stale records and the cap was never blocking anything. Those changes are **reverted** in this PR.

## The actual cause

From the daemon's own journal:

```
06:53:28  POST /add -> 200
06:53:56  TypeError: The first argument must be of type string ... Received undefined
            at arr2hex (uint8-util/dist/src/node.js:12)
            at Torrent._processParsedTorrent (webtorrent/lib/torrent.js:330)
06:53:56  torlink-serve.service: Main process exited, code=exited, status=1/FAILURE
06:54:01  Scheduled restart job, restart counter is at 4
```

`uint8-util` **2.3.x** restructured the package and broke `arr2hex`. It reaches us **transitively** through webtorrent on a caret range, so `npm i -g` silently resolves to it.

torlink accepts the magnet, starts fetching metadata, then dies on an **uncaught TypeError** — taking the in-memory queue with it. systemd restarts it and the torrent is simply gone. The app sees `200` from `/add` and never finds it in `/status`. The box had crashed **28 times**, once per send.

This explains every symptom: 200 from `/add`, both transports identical, nothing in `/status`, empty `queue.json`, worked-days-ago, and reinstalls never helping — **each reinstall re-fetched the broken version**. It's also why the GUI installer and a manual `npm i -g` behave identically: they run the same command.

Upstream already fixed it — `baairon/torlink@5293408 fix(boot): pin uint8-util 2.2.6 and self-heal boot after engine crashes`.

## Changes

- **Pin `uint8-util@2.2.6`** into the global package right after `npm i -g`, matching upstream's fix, so the installer stops re-introducing the crash. Placed after `PKG_ROOT` is assigned — the script runs under `set -u`, so referencing it earlier would abort the provision. Idempotent: re-pinning emits `skip`. Remove once the fork ships a release carrying the pin.
- **Rewrote `ADD_DROPPED_MESSAGE`**, which blamed a "wedged" daemon and told the user to restart it. The daemon is crashing, not wedged, and a restart alone changes nothing.

## Verification

Done against the live seedbox, not just in tests:

- Pinned 2.2.6 there and re-ran the add path end to end — `POST /add` → 200, **metadata parsed** (name resolved), torrent present in `/status`, daemon still `active` 45s later, **crash count unchanged**. Test torrent removed, no files left behind.
- Extracted the generated step from this PR's script and ran it against that box: reported `STEP|uint8|skip|uint8-util already pinned at 2.2.6` — confirming it's idempotent.
- `bash -n` clean on the generated provisioning script.
- Full suite: **181 files, 2497 passed**; typecheck and eslint clean.

## Related

`ralyodio/torlink#1` syncs the fork to upstream 1.5.1, which carries this pin properly. Once that's merged and published, this workaround can be dropped.

Independent of #149, though both touch `provision.ts`.