### PR TITLE
fix(rss): import whole-directory OPML files instead of rejecting them

### DIFF
--- a/src/app/api/rss/import/route.ts
+++ b/src/app/api/rss/import/route.ts
@@ -1,8 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getActiveProfileId } from '@/lib/profiles';
-import { importOpmlFeeds, parseOpmlFeeds } from '@/lib/rss-reader';
+import { importOpmlOutlines, parseOpmlFeeds } from '@/lib/rss-reader';
 
-const MAX_OPML_BYTES = 1_000_000;
+// Whole-directory OPML exports are big: Kagi's Small Web list is ~7 MB / 47k
+// feeds. nginx accepts 100 MB bodies (scripts/setup-server.sh), so this cap is
+// about bounding parser memory, not about rejecting real subscription lists.
+const MAX_OPML_BYTES = 25_000_000;
+
+function tooLargeMessage(): string {
+  return `OPML file is too large (limit ${Math.round(MAX_OPML_BYTES / 1_000_000)} MB)`;
+}
 
 async function readOpmlFromRequest(request: NextRequest): Promise<string | null> {
   const contentType = request.headers.get('content-type') ?? '';
@@ -12,7 +19,7 @@ async function readOpmlFromRequest(request: NextRequest): Promise<string | null>
     const file = formData.get('file');
     if (!(file instanceof File)) return null;
     if (file.size > MAX_OPML_BYTES) {
-      throw new Error('OPML file is too large');
+      throw new Error(tooLargeMessage());
     }
     return file.text();
   }
@@ -46,15 +53,17 @@ export async function POST(request: NextRequest): Promise<Response> {
     return NextResponse.json({ error: 'Missing OPML file or opml body' }, { status: 400 });
   }
 
-  if (opml.length > MAX_OPML_BYTES) {
-    return NextResponse.json({ error: 'OPML file is too large' }, { status: 400 });
+  if (Buffer.byteLength(opml, 'utf8') > MAX_OPML_BYTES) {
+    return NextResponse.json({ error: tooLargeMessage() }, { status: 400 });
   }
 
+  // Parse once and hand the outlines to the importer; re-parsing a multi-MB
+  // OPML just to count feeds doubles the peak memory of a large import.
   const outlines = parseOpmlFeeds(opml);
   if (outlines.length === 0) {
     return NextResponse.json({ error: 'No valid RSS feed URLs found in OPML' }, { status: 400 });
   }
 
-  const result = await importOpmlFeeds(profileId, opml);
+  const result = await importOpmlOutlines(profileId, outlines);
   return NextResponse.json(result);
 }

--- a/src/app/rss/rss-content.e2e.test.tsx
+++ b/src/app/rss/rss-content.e2e.test.tsx
@@ -69,7 +69,7 @@ describe('RSS reader browser flow', () => {
       if (url.startsWith('/api/rss/import')) {
         return Promise.resolve({
           ok: true,
-          json: async () => ({ total: 1, imported: [{ feedUrl: 'https://example.com/feed.xml', feedId: 'feed-1', title: 'Example Feed', folder: 'Tech' }], failed: [] }),
+          json: async () => ({ total: 1, imported: 1, fetched: 1, failed: 0, errors: [] }),
         });
       }
 

--- a/src/app/rss/rss-content.tsx
+++ b/src/app/rss/rss-content.tsx
@@ -63,8 +63,18 @@ interface RssResponse {
 
 interface ImportResponse {
   total: number;
-  imported: Array<{ feedUrl: string; feedId: string; title: string; folder: string | null }>;
-  failed: Array<{ feedUrl: string; title: string | null; error: string }>;
+  imported: number;
+  fetched: number;
+  failed: number;
+  errors: Array<{ feedUrl: string; error: string }>;
+}
+
+function importSummary(result: ImportResponse): string {
+  const parts = [`Imported ${result.imported} of ${result.total} feeds`];
+  const pending = result.imported - result.fetched - result.failed;
+  if (pending > 0) parts.push(`${pending} will load as you browse`);
+  if (result.failed > 0) parts.push(`${result.failed} failed to load`);
+  return `${parts.join('; ')}.`;
 }
 
 interface BulkReadStateResponse {
@@ -185,8 +195,7 @@ export function RssContent(): React.ReactElement {
       });
       const data = await response.json() as ImportResponse | { error?: string };
       if (!response.ok) throw new Error('error' in data ? data.error : 'Failed to import OPML');
-      const result = data as ImportResponse;
-      setImportMessage(`Imported ${result.imported.length} of ${result.total} feeds${result.failed.length ? `; ${result.failed.length} failed` : ''}.`);
+      setImportMessage(importSummary(data as ImportResponse));
       await loadReader();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to import OPML');

--- a/src/lib/rss-reader/repository.ts
+++ b/src/lib/rss-reader/repository.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from '@/lib/supabase';
 import type {
+  OpmlFeedOutline,
   ParsedRssFeed,
   ParsedRssItem,
   RssFeed,
@@ -75,6 +76,20 @@ interface BulkReadStateRpcClient {
     fn: 'rss_mark_items_read_state',
     params: { p_profile_id: string; p_feed_id: string | null; p_is_read: boolean }
   ): Promise<{ data: number | null; error: { message: string } | null }>;
+}
+
+interface OpmlImportRpcClient {
+  rpc(
+    fn: 'rss_import_opml_feeds',
+    params: { p_profile_id: string; p_feeds: OpmlFeedRecord[] }
+  ): Promise<{ data: number | null; error: { message: string } | null }>;
+}
+
+interface OpmlFeedRecord {
+  feed_url: string;
+  site_url: string | null;
+  title: string | null;
+  folder: string | null;
 }
 
 function db() {
@@ -242,6 +257,35 @@ export async function subscribeToFeed(
     updatedAt: row.updated_at,
     feed: rowToFeed(row.rss_feeds as FeedRow),
   };
+}
+
+/**
+ * Subscribe a profile to every outline in one batch, creating feed rows for the
+ * ones we have never seen. Feeds land without fetch state; items arrive when
+ * the feed is first refreshed.
+ */
+export async function bulkSubscribeToOpmlFeeds(
+  profileId: string,
+  outlines: OpmlFeedOutline[]
+): Promise<number> {
+  if (outlines.length === 0) return 0;
+
+  const rpcClient = db() as unknown as OpmlImportRpcClient;
+  const { data, error } = await rpcClient.rpc('rss_import_opml_feeds', {
+    p_profile_id: profileId,
+    p_feeds: outlines.map((outline) => ({
+      feed_url: outline.feedUrl,
+      site_url: outline.siteUrl,
+      title: outline.title,
+      folder: outline.folder,
+    })),
+  });
+
+  if (error) {
+    throw new Error(`Failed to import OPML feeds: ${error.message}`);
+  }
+
+  return typeof data === 'number' ? data : 0;
 }
 
 export async function listSubscriptions(profileId: string): Promise<RssSubscription[]> {

--- a/src/lib/rss-reader/service.test.ts
+++ b/src/lib/rss-reader/service.test.ts
@@ -1,0 +1,116 @@
+/**
+ * OPML import tests.
+ *
+ * The import path has to survive whole-directory OPML files (Kagi's Small Web
+ * list is ~47k feeds), so it subscribes in bulk and only loads articles for as
+ * many feeds as fit in a time budget.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { OpmlFeedOutline } from './types';
+
+const bulkSubscribeToOpmlFeeds = vi.fn();
+const upsertFeed = vi.fn();
+const upsertFeedItems = vi.fn();
+
+vi.mock('./repository', () => ({
+  bulkSubscribeToOpmlFeeds: (...args: unknown[]) => bulkSubscribeToOpmlFeeds(...args),
+  upsertFeed: (...args: unknown[]) => upsertFeed(...args),
+  upsertFeedItems: (...args: unknown[]) => upsertFeedItems(...args),
+  deleteSubscription: vi.fn(),
+  getFeedById: vi.fn(),
+  hasActiveSubscription: vi.fn(),
+  listItems: vi.fn(),
+  listSubscriptions: vi.fn(),
+  markFeedFetchError: vi.fn(),
+  subscribeToFeed: vi.fn(),
+  updateItemState: vi.fn(),
+  updateItemsReadState: vi.fn(),
+  updateSubscription: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase', () => ({ createServerClient: vi.fn() }));
+vi.mock('@/lib/email-accounts', () => ({ getEmailAccount: vi.fn() }));
+vi.mock('@/lib/email-reader', () => ({
+  buildPrivateSenderFeedXml: vi.fn(),
+  extractEmailAddress: vi.fn(() => null),
+}));
+vi.mock('@/lib/subscription/check', () => ({ isPaidSubscriptionActive: vi.fn() }));
+
+const { importOpmlOutlines } = await import('./service');
+
+function feedXml(title: string): string {
+  return `<?xml version="1.0"?><rss version="2.0"><channel><title>${title}</title>
+    <item><title>Post</title><link>https://example.com/post</link></item>
+  </channel></rss>`;
+}
+
+function outlines(count: number, prefix = 'feed'): OpmlFeedOutline[] {
+  return Array.from({ length: count }, (_, index) => ({
+    title: `${prefix} ${index}`,
+    feedUrl: `https://${prefix}-${index}.example.com/rss`,
+    siteUrl: `https://${prefix}-${index}.example.com/`,
+    folder: 'Small Web',
+  }));
+}
+
+describe('importOpmlOutlines', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    bulkSubscribeToOpmlFeeds.mockImplementation((_profileId: string, chunk: OpmlFeedOutline[]) =>
+      Promise.resolve(chunk.length)
+    );
+    upsertFeed.mockImplementation(() => Promise.resolve({ id: 'feed-id' }));
+    upsertFeedItems.mockResolvedValue([]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response(feedXml('Example'), { status: 200 })))
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('subscribes in bulk and reports what it loaded', async () => {
+    const result = await importOpmlOutlines('profile-1', outlines(3));
+
+    expect(bulkSubscribeToOpmlFeeds).toHaveBeenCalledTimes(1);
+    expect(bulkSubscribeToOpmlFeeds).toHaveBeenCalledWith('profile-1', expect.any(Array));
+    expect(result).toMatchObject({ total: 3, imported: 3, fetched: 3, failed: 0 });
+    expect(result.errors).toEqual([]);
+  });
+
+  it('splits large imports into chunked RPC calls', async () => {
+    // 4500 feeds at 2000 per call; skip the network entirely so the test is fast.
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('offline'))));
+
+    const result = await importOpmlOutlines('profile-1', outlines(4500));
+
+    expect(bulkSubscribeToOpmlFeeds).toHaveBeenCalledTimes(3);
+    const chunkSizes = bulkSubscribeToOpmlFeeds.mock.calls.map((call) => call[1].length);
+    expect(chunkSizes).toEqual([2000, 2000, 500]);
+    expect(result.total).toBe(4500);
+    expect(result.imported).toBe(4500);
+  });
+
+  it('keeps subscriptions when a feed fails to load, and caps reported errors', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response('nope', { status: 500 }))));
+
+    const result = await importOpmlOutlines('profile-1', outlines(30));
+
+    expect(result.imported).toBe(30);
+    expect(result.fetched).toBe(0);
+    expect(result.failed).toBe(30);
+    expect(result.errors).toHaveLength(20);
+    expect(result.errors[0].error).toContain('HTTP 500');
+  });
+
+  it('does not fetch when there is nothing to import', async () => {
+    const result = await importOpmlOutlines('profile-1', []);
+
+    expect(bulkSubscribeToOpmlFeeds).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ total: 0, imported: 0, fetched: 0, failed: 0 });
+  });
+});

--- a/src/lib/rss-reader/service.ts
+++ b/src/lib/rss-reader/service.ts
@@ -4,6 +4,7 @@ import { buildPrivateSenderFeedXml, extractEmailAddress } from '@/lib/email-read
 import { createServerClient } from '@/lib/supabase';
 import { isPaidSubscriptionActive } from '@/lib/subscription/check';
 import {
+  bulkSubscribeToOpmlFeeds,
   deleteSubscription,
   getFeedById,
   hasActiveSubscription,
@@ -21,6 +22,14 @@ import type { OpmlFeedOutline, RssItemStateInput, RssListOptions, RssSubscriptio
 
 const MAX_FEED_BYTES = 1_000_000;
 const FETCH_TIMEOUT_MS = 15_000;
+
+/** Feeds per rss_import_opml_feeds call — keeps the JSON payload around 300 KB. */
+const OPML_IMPORT_CHUNK = 2_000;
+const OPML_WARM_BUDGET_MS = 20_000;
+const WARM_CONCURRENCY = 8;
+const MAX_REPORTED_ERRORS = 20;
+/** Feeds refreshed per reader load; a 47k-feed import must not stampede. */
+const LAZY_FETCH_LIMIT = 24;
 
 interface PrivateSenderFeedParams {
   origin: string;
@@ -156,45 +165,97 @@ export async function subscribeToRssFeed(
 }
 
 export interface OpmlImportResult {
+  /** Feed outlines found in the OPML. */
   total: number;
-  imported: Array<{ feedUrl: string; feedId: string; title: string; folder: string | null }>;
-  failed: Array<{ feedUrl: string; title: string | null; error: string }>;
+  /** Subscriptions created or reactivated for this profile. */
+  imported: number;
+  /** Feeds whose articles were loaded before this request returned. */
+  fetched: number;
+  /** Feeds that failed to load; they stay subscribed and are retried later. */
+  failed: number;
+  /** A sample of load errors — a 47k-feed import must not return 47k strings. */
+  errors: Array<{ feedUrl: string; error: string }>;
 }
 
 export function parseOpmlFeeds(opml: string): OpmlFeedOutline[] {
   return parseOpmlXml(opml);
 }
 
-export async function importOpmlFeeds(profileId: string, opml: string): Promise<OpmlImportResult> {
-  const outlines = parseOpmlXml(opml);
-  const result: OpmlImportResult = {
-    total: outlines.length,
-    imported: [],
-    failed: [],
-  };
+/**
+ * Load articles for freshly imported feeds, in OPML order, until the time
+ * budget runs out. Whatever we don't get to stays unfetched and
+ * is filled in by populateUnfetchedFeeds on later reader loads — a large OPML
+ * must not hold the import request open for one network round trip per feed.
+ */
+async function warmFeeds(
+  profileId: string,
+  feedUrls: string[],
+  budgetMs: number
+): Promise<{ fetched: number; failed: number; errors: OpmlImportResult['errors'] }> {
+  const deadline = Date.now() + budgetMs;
+  const errors: OpmlImportResult['errors'] = [];
+  let fetched = 0;
+  let failed = 0;
+  let cursor = 0;
 
-  for (const outline of outlines) {
-    try {
-      const subscription = await subscribeToRssFeed(profileId, outline.feedUrl, false, {
-        customTitle: outline.title,
-        folder: outline.folder,
-      });
-      result.imported.push({
-        feedUrl: subscription.feed.feedUrl,
-        feedId: subscription.feedId,
-        title: subscription.customTitle ?? subscription.feed.title,
-        folder: subscription.folder,
-      });
-    } catch (error) {
-      result.failed.push({
-        feedUrl: outline.feedUrl,
-        title: outline.title,
-        error: error instanceof Error ? error.message : 'Failed to import feed',
-      });
-    }
+  const workerCount = Math.min(WARM_CONCURRENCY, feedUrls.length);
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (cursor < feedUrls.length && Date.now() < deadline) {
+        const feedUrl = feedUrls[cursor];
+        cursor += 1;
+
+        try {
+          const xml = await loadFeedXml(profileId, feedUrl);
+          const parsed = parseFeedXml(xml, feedUrl);
+          if (!parsed) {
+            throw new Error('Could not parse RSS or Atom feed');
+          }
+          const feed = await upsertFeed({ ...parsed, feedUrl });
+          await upsertFeedItems(feed.id, parsed.items);
+          fetched += 1;
+        } catch (error) {
+          failed += 1;
+          if (errors.length < MAX_REPORTED_ERRORS) {
+            errors.push({
+              feedUrl,
+              error: error instanceof Error ? error.message : 'Failed to load feed',
+            });
+          }
+        }
+      }
+    })
+  );
+
+  return { fetched, failed, errors };
+}
+
+export async function importOpmlOutlines(
+  profileId: string,
+  outlines: OpmlFeedOutline[]
+): Promise<OpmlImportResult> {
+  let imported = 0;
+  for (let index = 0; index < outlines.length; index += OPML_IMPORT_CHUNK) {
+    imported += await bulkSubscribeToOpmlFeeds(profileId, outlines.slice(index, index + OPML_IMPORT_CHUNK));
   }
 
-  return result;
+  const warmed = await warmFeeds(
+    profileId,
+    outlines.map((outline) => outline.feedUrl),
+    OPML_WARM_BUDGET_MS
+  );
+
+  return {
+    total: outlines.length,
+    imported,
+    fetched: warmed.fetched,
+    failed: warmed.failed,
+    errors: warmed.errors,
+  };
+}
+
+export async function importOpmlFeeds(profileId: string, opml: string): Promise<OpmlImportResult> {
+  return importOpmlOutlines(profileId, parseOpmlXml(opml));
 }
 
 function escapeXml(value: string): string {
@@ -299,15 +360,19 @@ export async function refreshRssFeed(profileId: string, feedId: string): Promise
 }
 
 // Default feed subscriptions (Profullstack, Inc. folder) are seeded directly in
-// the database via migration/trigger, so they have no items until first fetched.
-// On reader load, fetch any subscribed feed that has never been fetched so the
-// seeded feeds are not empty. Best-effort and one-shot per feed: a failed fetch
-// still sets last_fetched_at, so we never retry it automatically on every load.
+// the database via migration/trigger, and OPML imports subscribe without
+// fetching, so both start with no items. On reader load, fetch feeds that have
+// never been fetched. Best-effort and one-shot per feed: a failed fetch still
+// sets last_fetched_at, so we never retry it automatically on every load.
+// Capped per load — an OPML import can leave tens of thousands of feeds
+// unfetched, and firing them all at once would hang the reader.
 async function populateUnfetchedFeeds(
   profileId: string,
   subscriptions: Awaited<ReturnType<typeof listSubscriptions>>
 ): Promise<void> {
-  const unfetched = subscriptions.filter((subscription) => !subscription.feed.lastFetchedAt);
+  const unfetched = subscriptions
+    .filter((subscription) => !subscription.feed.lastFetchedAt)
+    .slice(0, LAZY_FETCH_LIMIT);
   if (unfetched.length === 0) return;
 
   await Promise.allSettled(

--- a/supabase/migrations/20260803120000_rss_bulk_opml_import.sql
+++ b/supabase/migrations/20260803120000_rss_bulk_opml_import.sql
@@ -1,0 +1,73 @@
+-- Bulk OPML import for the RSS reader.
+--
+-- Importing a large OPML (Kagi Small Web is ~47k feeds) one feed at a time is
+-- two round trips per feed, which no HTTP request can survive. This does the
+-- whole batch as a single statement: insert the feeds we don't have yet, then
+-- subscribe the profile to every feed in the batch.
+
+CREATE OR REPLACE FUNCTION public.rss_import_opml_feeds(
+  p_profile_id UUID,
+  p_feeds JSONB
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count INTEGER := 0;
+BEGIN
+  WITH incoming AS (
+    SELECT DISTINCT ON (feed.feed_url)
+      feed.feed_url,
+      NULLIF(BTRIM(feed.site_url), '') AS site_url,
+      COALESCE(NULLIF(BTRIM(feed.title), ''), feed.feed_url) AS title,
+      NULLIF(BTRIM(feed.folder), '') AS folder
+    FROM jsonb_to_recordset(p_feeds)
+      AS feed(feed_url TEXT, site_url TEXT, title TEXT, folder TEXT)
+    WHERE NULLIF(BTRIM(feed.feed_url), '') IS NOT NULL
+    ORDER BY feed.feed_url
+  ),
+  -- Insert new feeds only. An OPML outline carries no fetch state, so it must
+  -- never overwrite the title or items of a feed somebody has already fetched.
+  inserted_feeds AS (
+    INSERT INTO rss_feeds (feed_url, site_url, title)
+    SELECT feed_url, site_url, title FROM incoming
+    ON CONFLICT (feed_url) DO NOTHING
+    RETURNING id, feed_url
+  ),
+  -- CTEs read the pre-statement snapshot, so rows from inserted_feeds are not
+  -- visible in a plain scan of rss_feeds and have to be unioned back in.
+  resolved AS (
+    SELECT DISTINCT ON (matched.feed_url)
+      matched.id AS feed_id,
+      incoming.title,
+      incoming.folder
+    FROM incoming
+    JOIN (
+      SELECT id, feed_url FROM inserted_feeds
+      UNION ALL
+      SELECT id, feed_url FROM rss_feeds
+      WHERE feed_url IN (SELECT feed_url FROM incoming)
+    ) AS matched ON matched.feed_url = incoming.feed_url
+    ORDER BY matched.feed_url
+  ),
+  subscribed AS (
+    INSERT INTO rss_subscriptions (
+      profile_id, feed_id, custom_title, folder, notify_new_items, is_active
+    )
+    SELECT p_profile_id, feed_id, title, folder, FALSE, TRUE FROM resolved
+    ON CONFLICT (profile_id, feed_id) DO UPDATE
+      SET folder = COALESCE(EXCLUDED.folder, rss_subscriptions.folder),
+          is_active = TRUE,
+          updated_at = NOW()
+    RETURNING 1
+  )
+  SELECT COUNT(*) INTO v_count FROM subscribed;
+
+  RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rss_import_opml_feeds(UUID, JSONB) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.rss_import_opml_feeds(UUID, JSONB) TO service_role;


### PR DESCRIPTION
## Problem

Importing `~/smallweb.opml` (Kagi's Small Web list — **7.2 MB, 47,233 feeds**) failed with `OPML file is too large`. The cap was 1 MB.

Raising the cap alone would have traded one failure for a worse one: `importOpmlFeeds` looped over outlines and called `subscribeToRssFeed` per feed, each of which does a network fetch with a 15 s timeout plus two DB round trips — 47k of them, sequentially, inside one HTTP request.

## Changes

- **Cap raised to 25 MB**, measured with `Buffer.byteLength` rather than `String.length` (UTF-16 units under-count multibyte OPML). nginx already accepts 100 MB bodies, so the cap is only there to bound parser memory.
- **New `rss_import_opml_feeds()` RPC** (migration `20260803120000`): inserts feeds we don't have and subscribes the profile to the entire batch in one statement. Feeds are inserted with `ON CONFLICT DO NOTHING`, so an OPML outline can never overwrite the title or fetch state of a feed someone has already fetched. The importer sends 2,000 feeds per call — ~24 round trips for the Small Web list instead of ~94,000.
- **Bounded warm-up**: after subscribing, articles load for as many feeds as fit in a 20 s budget at 8 concurrent fetches. Everything else stays subscribed and unfetched.
- **Bounded lazy backfill**: `populateUnfetchedFeeds` used `Promise.allSettled` over *every* unfetched subscription on each reader load. With a large import that's a stampede; it now refreshes 24 per load.
- **Parse once**: the route parsed the OPML to count outlines and the service parsed it again to import. On a 7 MB file that doubled peak memory.
- **Response shape**: `{ total, imported, fetched, failed, errors }` (counts + at most 20 sample errors) instead of one object per feed — a 47k-feed import previously would have returned a multi-megabyte JSON body. The reader's status line was updated to match.

## Deploying

**The migration is already applied to the linked project (`ussbjnpovrynxyztjeeb`, bittorrented.com)** via `supabase db push`, so this branch is safe to merge as-is.

Note for whoever pushes next: the remote history had pre-existing drift — four migrations exist on the remote under different timestamps than their local twins (`20260709115247`/`20260709120000`, `20260712231313`/`20260712173000`, `20260725101107`/`20260725120000`, `20260725105010`/`20260725130000`), and `20260625095627_tronbrowser_api_tokens` is local-only and still unapplied. A plain `supabase db push` therefore fails with `LegacyDbPushMissingLocalError`. This migration was applied on its own, without touching that drift or the unapplied tronbrowser migration.

## Testing

- `pnpm test` — 2509 passed, 7 skipped, 182 files
- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors (247 pre-existing warnings, none in touched files)
- `pnpm build` — succeeds
- New `src/lib/rss-reader/service.test.ts` covers bulk chunking at 2,000/call, error capping, feeds staying subscribed when a fetch fails, and the empty-import case.

Against the live database, after applying the migration:
- `rss_import_opml_feeds(<uuid>, '[]')` returns `0` — every statement plans against the real schema.
- Calling it with one feed and a nonexistent profile fails with `23503` on `rss_subscriptions_profile_id_fkey`, which proves the batch parsed, the feed inserted, and the feed id resolved through the CTE before the subscription insert. The whole call rolled back; `rss_feeds` has no probe row left behind.

## Known limits (unchanged by this PR)

`listSubscriptions` has no pagination, so PostgREST's default 1,000-row ceiling applies to the reader sidebar. A 47k-feed subscription list will display truncated until that query is paginated — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
