### PR TITLE
feat(finance): export watchlists as a CSV with prices, ticker leftmost

### DIFF
--- a/src/app/finance/watchlist-section.tsx
+++ b/src/app/finance/watchlist-section.tsx
@@ -17,20 +17,23 @@ import { useVisibleInterval } from '@/lib/finance/use-visible-interval';
 import {
   MAX_WATCHLIST_NAME,
   WATCHLISTS_EXPORT_FILENAME,
-  formatSymbolsCsv,
-  formatWatchlistsExport,
+  formatWatchlistsCsv,
   parseSymbolList,
+  parseWatchlistsCsv,
   parseWatchlistsExport,
   uniqueWatchlistName,
   watchlistExportFilename,
   watchlistNameFromFilename,
 } from '@/lib/finance/watchlist';
-import type { NamedWatchlist } from '@/lib/finance/watchlist';
+import type { NamedWatchlist, WatchlistCsvData } from '@/lib/finance/watchlist';
 import type { WatchlistChanges } from '@/lib/finance/performance';
 import type { Quote } from '@/lib/finance/market-data/types';
 
 /** Live-quote poll cadence (ms) while the tab is visible. */
 const QUOTE_POLL_MS = 20_000;
+
+/** Symbols per quotes/changes request — both routes cap a call at 60. */
+const QUOTE_CHUNK = 60;
 
 interface WatchlistRow {
   id: string;
@@ -286,17 +289,54 @@ export function WatchlistSection(): React.ReactElement {
     URL.revokeObjectURL(url);
   }, []);
 
-  /** Download the active list as comma-separated, alphabetical tickers. */
-  const exportList = useCallback(() => {
-    const csv = formatSymbolsCsv(watchlist.map((row) => row.symbol));
-    if (!csv) return;
-    download(csv, watchlistExportFilename(activeList?.name ?? 'watchlist'));
-  }, [watchlist, activeList, download]);
+  /**
+   * Pull quotes + trailing changes for the symbols being exported. Both routes
+   * cap a request at 60 symbols, so a big export goes out in chunks; a failed
+   * chunk just leaves those price cells blank rather than sinking the file.
+   */
+  const fetchMarketData = useCallback(async (symbols: string[]): Promise<WatchlistCsvData> => {
+    const quotes: Record<string, Quote> = {};
+    const changes: Record<string, WatchlistChanges> = {};
+    const chunks: string[][] = [];
+    for (let i = 0; i < symbols.length; i += QUOTE_CHUNK) chunks.push(symbols.slice(i, i + QUOTE_CHUNK));
+
+    await Promise.all(
+      chunks.map(async (chunk) => {
+        const query = encodeURIComponent(chunk.join(','));
+        const [q, c] = await Promise.all([
+          fetch(`/api/finance/quotes?symbols=${query}`, { cache: 'no-store' })
+            .then((res) => (res.ok ? res.json() : { quotes: {} }))
+            .catch(() => ({ quotes: {} })),
+          fetch(`/api/finance/watchlist/changes?symbols=${query}`, { cache: 'no-store' })
+            .then((res) => (res.ok ? res.json() : { changes: {} }))
+            .catch(() => ({ changes: {} })),
+        ]);
+        Object.assign(quotes, (q as { quotes?: Record<string, Quote> }).quotes ?? {});
+        Object.assign(changes, (c as { changes?: Record<string, WatchlistChanges> }).changes ?? {});
+      }),
+    );
+
+    return { quotes, changes };
+  }, []);
+
+  /** Download the active list as a CSV: one row per ticker, with its prices. */
+  const exportList = useCallback(async () => {
+    const symbols = parseSymbolList(watchlist.map((row) => row.symbol)).valid;
+    if (symbols.length === 0) return;
+    setBulkBusy(true);
+    try {
+      const name = activeList?.name ?? 'watchlist';
+      const data = await fetchMarketData(symbols);
+      download(formatWatchlistsCsv([{ name, symbols }], data), watchlistExportFilename(name));
+    } finally {
+      setBulkBusy(false);
+    }
+  }, [watchlist, activeList, download, fetchMarketData]);
 
   /**
-   * Download every list in one file — one `Name,TICKER,…` line per list. Each
-   * list's tickers are fetched on demand, since only the active list's items
-   * are held in state.
+   * Download every list in one CSV — one row per ticker, tagged with its list
+   * and carrying its prices. Each list's tickers are fetched on demand, since
+   * only the active list's items are held in state.
    */
   const exportAllLists = useCallback(async () => {
     if (lists.length === 0) return;
@@ -312,15 +352,16 @@ export function WatchlistSection(): React.ReactElement {
           return { name: list.name, symbols: (body.watchlist ?? []).map((row) => row.symbol) };
         }),
       );
-      download(formatWatchlistsExport(named), WATCHLISTS_EXPORT_FILENAME);
-      const total = named.reduce((sum, l) => sum + l.symbols.length, 0);
-      setBulkMsg(`Exported ${named.length} list${named.length === 1 ? '' : 's'} · ${total} tickers.`);
+      const symbols = parseSymbolList(named.flatMap((l) => l.symbols)).valid;
+      const data = await fetchMarketData(symbols);
+      download(formatWatchlistsCsv(named, data), WATCHLISTS_EXPORT_FILENAME);
+      setBulkMsg(`Exported ${named.length} list${named.length === 1 ? '' : 's'} · ${symbols.length} tickers.`);
     } catch {
       setBulkMsg('Could not export your lists.');
     } finally {
       setBulkBusy(false);
     }
-  }, [lists, download]);
+  }, [lists, download, fetchMarketData]);
 
   /** Create a list and return its id, or undefined when the server refuses. */
   const createNamedList = useCallback(async (name: string): Promise<string | undefined> => {
@@ -400,7 +441,8 @@ export function WatchlistSection(): React.ReactElement {
         return;
       }
 
-      const bundle = parseWatchlistsExport(text);
+      const fileName = watchlistNameFromFilename(file.name);
+      const bundle = parseWatchlistsCsv(text, fileName) ?? parseWatchlistsExport(text);
       if (bundle) {
         if (bundle.length === 0) {
           setBulkMsg('That file has no lists in it.');
@@ -416,7 +458,7 @@ export function WatchlistSection(): React.ReactElement {
       }
 
       const name = uniqueWatchlistName(
-        watchlistNameFromFilename(file.name),
+        fileName,
         lists.map((l) => l.name),
       );
       // On failure newId stays undefined and the import falls back to the
@@ -557,9 +599,9 @@ export function WatchlistSection(): React.ReactElement {
         </button>
         <button
           type="button"
-          onClick={exportList}
-          disabled={watchlist.length === 0}
-          title="Download this list's tickers"
+          onClick={() => void exportList()}
+          disabled={bulkBusy || watchlist.length === 0}
+          title="Download this list as a CSV: one row per ticker, with prices"
           className="text-text-muted hover:text-text-secondary hover:underline disabled:opacity-40"
         >
           Export
@@ -568,7 +610,7 @@ export function WatchlistSection(): React.ReactElement {
           type="button"
           onClick={() => void exportAllLists()}
           disabled={bulkBusy || lists.length === 0}
-          title="Download every list in one file"
+          title="Download every list in one CSV: one row per ticker, with prices"
           className="text-text-muted hover:text-text-secondary hover:underline disabled:opacity-40"
         >
           Export all

--- a/src/lib/finance/watchlist.test.ts
+++ b/src/lib/finance/watchlist.test.ts
@@ -3,8 +3,10 @@ import {
   parseSymbolList,
   sanitizeWatchlistName,
   formatSymbolsCsv,
-  formatWatchlistsExport,
+  formatWatchlistsCsv,
+  parseWatchlistsCsv,
   parseWatchlistsExport,
+  WATCHLIST_CSV_COLUMNS,
   watchlistExportFilename,
   watchlistNameFromFilename,
   uniqueWatchlistName,
@@ -70,51 +72,135 @@ describe('watchlistExportFilename', () => {
   });
 });
 
-describe('formatWatchlistsExport / parseWatchlistsExport', () => {
+describe('formatWatchlistsCsv', () => {
   const lists = [
     { name: 'Tech', symbols: ['NVDA', 'AAPL'] },
     { name: 'Energy', symbols: ['XOM'] },
   ];
 
-  it('writes a header, one sorted line per list, tickers alphabetical', () => {
-    expect(formatWatchlistsExport(lists)).toBe(['#watchlists', 'Energy,XOM', 'Tech,AAPL,NVDA'].join('\n'));
+  const header = WATCHLIST_CSV_COLUMNS.join(',');
+
+  it('puts the ticker leftmost, one row per stock, lists and tickers sorted', () => {
+    const rows = formatWatchlistsCsv(lists).split('\n');
+    expect(rows[0]).toBe(header);
+    expect(rows.slice(1).map((r) => r.split(',').slice(0, 2).join(','))).toEqual([
+      'XOM,Energy',
+      'AAPL,Tech',
+      'NVDA,Tech',
+    ]);
   });
 
-  it('round-trips through the parser', () => {
-    const parsed = parseWatchlistsExport(formatWatchlistsExport(lists));
-    expect(parsed).toEqual([
+  it('fills the price columns from quote + change data', () => {
+    const text = formatWatchlistsCsv([{ name: 'Tech', symbols: ['AAPL'] }], {
+      quotes: {
+        AAPL: {
+          price: 123.456,
+          change: -1.2,
+          changePercent: -0.964,
+          open: 124,
+          high: 125,
+          low: 122.5,
+          previousClose: 124.656,
+          volume: 54_321_000,
+          asOf: Date.parse('2026-08-01T00:00:00Z') / 1000,
+        },
+      },
+      changes: { AAPL: { d1: -0.96, d5: 2.115, d30: null } },
+    });
+    expect(text.split('\n')[1]).toBe(
+      'AAPL,Tech,123.46,-1.20,-0.96,-0.96,2.12,,124.00,125.00,122.50,124.66,54321000,2026-08-01',
+    );
+  });
+
+  it('leaves price cells blank when the provider has no data', () => {
+    const row = formatWatchlistsCsv([{ name: 'Tech', symbols: ['AAPL'] }]).split('\n')[1];
+    expect(row).toBe(`AAPL,Tech${','.repeat(WATCHLIST_CSV_COLUMNS.length - 2)}`);
+  });
+
+  it('quotes list names containing commas or quotes', () => {
+    const text = formatWatchlistsCsv([{ name: 'Big, "risky" names', symbols: ['SPY'] }]);
+    expect(text).toContain('SPY,"Big, ""risky"" names"');
+  });
+});
+
+describe('parseWatchlistsCsv', () => {
+  it('round-trips an exported file back into lists', () => {
+    const lists = [
+      { name: 'Energy', symbols: ['XOM'] },
+      { name: 'Tech', symbols: ['AAPL', 'NVDA'] },
+    ];
+    expect(parseWatchlistsCsv(formatWatchlistsCsv(lists), 'ignored')).toEqual(lists);
+  });
+
+  it('round-trips list names that needed quoting', () => {
+    const lists = [{ name: 'Big, "risky" names', symbols: ['SPY'] }];
+    expect(parseWatchlistsCsv(formatWatchlistsCsv(lists), 'ignored')).toEqual(lists);
+  });
+
+  it('keeps empty lists', () => {
+    const text = formatWatchlistsCsv([{ name: 'Empty', symbols: [] }]);
+    expect(parseWatchlistsCsv(text, 'ignored')).toEqual([{ name: 'Empty', symbols: [] }]);
+  });
+
+  it('ignores the price columns and tolerates extra ones', () => {
+    const text = 'Symbol,List,Price,Notes\nAAPL,Tech,123.45,buy more\nXOM,Energy,98.10,\n';
+    expect(parseWatchlistsCsv(text, 'ignored')).toEqual([
+      { name: 'Tech', symbols: ['AAPL'] },
+      { name: 'Energy', symbols: ['XOM'] },
+    ]);
+  });
+
+  it('falls back to the file name when there is no List column or the cell is blank', () => {
+    expect(parseWatchlistsCsv('Symbol,Price\nAAPL,1\nNVDA,2\n', 'My File')).toEqual([
+      { name: 'My File', symbols: ['AAPL', 'NVDA'] },
+    ]);
+    expect(parseWatchlistsCsv('Symbol,List\nAAPL,\n', 'My File')).toEqual([{ name: 'My File', symbols: ['AAPL'] }]);
+  });
+
+  it('de-dupes repeated tickers and skips junk ones', () => {
+    const text = 'Symbol,List\nAAPL,Tech\naapl,Tech\n$$$,Tech\nNVDA,Tech\n';
+    expect(parseWatchlistsCsv(text, 'ignored')).toEqual([{ name: 'Tech', symbols: ['AAPL', 'NVDA'] }]);
+  });
+
+  it('tolerates CRLF and blank lines', () => {
+    expect(parseWatchlistsCsv('Symbol,List\r\n\r\nAAPL,Tech\r\n', 'ignored')).toEqual([
+      { name: 'Tech', symbols: ['AAPL'] },
+    ]);
+  });
+
+  it('returns null for a plain ticker list, so it imports as a single list', () => {
+    expect(parseWatchlistsCsv('AAPL,NVDA,SPY', 'f')).toBeNull();
+    expect(parseWatchlistsCsv('AAPL\nNVDA', 'f')).toBeNull();
+    expect(parseWatchlistsCsv('', 'f')).toBeNull();
+  });
+});
+
+describe('parseWatchlistsExport (legacy #watchlists files)', () => {
+  it('still restores files exported before the CSV format', () => {
+    expect(parseWatchlistsExport('#watchlists\nEnergy,XOM\nTech,AAPL,NVDA')).toEqual([
       { name: 'Energy', symbols: ['XOM'] },
       { name: 'Tech', symbols: ['AAPL', 'NVDA'] },
     ]);
   });
 
-  it('quotes and round-trips names containing commas or quotes', () => {
-    const tricky = [{ name: 'Big, "risky" names', symbols: ['SPY'] }];
-    const text = formatWatchlistsExport(tricky);
-    expect(text).toContain('"Big, ""risky"" names",SPY');
-    expect(parseWatchlistsExport(text)).toEqual(tricky);
+  it('unquotes names that carried commas or quotes', () => {
+    expect(parseWatchlistsExport('#watchlists\n"Big, ""risky"" names",SPY')).toEqual([
+      { name: 'Big, "risky" names', symbols: ['SPY'] },
+    ]);
   });
 
   it('keeps empty lists', () => {
-    const text = formatWatchlistsExport([{ name: 'Empty', symbols: [] }]);
-    expect(text).toBe('#watchlists\nEmpty');
-    expect(parseWatchlistsExport(text)).toEqual([{ name: 'Empty', symbols: [] }]);
+    expect(parseWatchlistsExport('#watchlists\nEmpty')).toEqual([{ name: 'Empty', symbols: [] }]);
   });
 
-  it('returns null for a plain ticker list, so it imports as a single list', () => {
+  it('returns null for anything without the sentinel', () => {
     expect(parseWatchlistsExport('AAPL,NVDA,SPY')).toBeNull();
-    expect(parseWatchlistsExport('AAPL\nNVDA')).toBeNull();
+    expect(parseWatchlistsExport('Symbol,List\nAAPL,Tech')).toBeNull();
     expect(parseWatchlistsExport('')).toBeNull();
   });
 
   it('tolerates blank lines and CRLF', () => {
     expect(parseWatchlistsExport('#watchlists\r\n\r\nTech,AAPL\r\n')).toEqual([{ name: 'Tech', symbols: ['AAPL'] }]);
-  });
-
-  it('skips junk tickers within a line', () => {
-    expect(parseWatchlistsExport('#watchlists\nTech,AAPL,$$$,NVDA')).toEqual([
-      { name: 'Tech', symbols: ['AAPL', 'NVDA'] },
-    ]);
   });
 });
 

--- a/src/lib/finance/watchlist.ts
+++ b/src/lib/finance/watchlist.ts
@@ -35,9 +35,9 @@ export function formatSymbolsCsv(symbols: string[]): string {
 }
 
 /**
- * First line of an all-lists export. Import keys off this sentinel to tell a
- * multi-list file from a plain ticker list — without it, a multi-line ticker
- * file would be ambiguous (is the first field a list name or a symbol?).
+ * First line of the pre-CSV all-lists export (`#watchlists`, one
+ * `Name,TICKER,…` line per list). Still parsed on import so files exported
+ * before the spreadsheet format shipped keep working.
  */
 export const WATCHLISTS_EXPORT_HEADER = '#watchlists';
 
@@ -49,54 +49,9 @@ export interface NamedWatchlist {
   symbols: string[];
 }
 
-/** Quote a list name if it would otherwise collide with the field separator. */
-function quoteName(name: string): string {
-  return /["\n,]/.test(name) ? `"${name.replace(/"/g, '""')}"` : name;
-}
-
-/** Split a line into its (possibly quoted) leading name and the rest. */
-function splitNameAndRest(line: string): [string, string] {
-  if (!line.startsWith('"')) {
-    const comma = line.indexOf(',');
-    return comma === -1 ? [line, ''] : [line.slice(0, comma), line.slice(comma + 1)];
-  }
-  let name = '';
-  let i = 1;
-  while (i < line.length) {
-    if (line[i] === '"') {
-      if (line[i + 1] === '"') {
-        name += '"';
-        i += 2;
-        continue;
-      }
-      i += 1;
-      break;
-    }
-    name += line[i];
-    i += 1;
-  }
-  // `i` now sits just past the closing quote; the rest follows its comma.
-  return [name, line[i] === ',' ? line.slice(i + 1) : ''];
-}
-
 /**
- * Render every list as one file: a sentinel line, then one line per list —
- * `Name,TICKER,TICKER,…` with tickers alphabetical and the lists themselves
- * sorted by name. Empty lists are kept so the file round-trips exactly.
- */
-export function formatWatchlistsExport(lists: NamedWatchlist[]): string {
-  const lines = [...lists]
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .map((list) => {
-      const csv = formatSymbolsCsv(list.symbols);
-      return csv ? `${quoteName(list.name)},${csv}` : quoteName(list.name);
-    });
-  return [WATCHLISTS_EXPORT_HEADER, ...lines].join('\n');
-}
-
-/**
- * Parse an all-lists export. Returns null when the sentinel is absent, i.e.
- * the file is a plain ticker list and the caller should treat it as one list.
+ * Parse the legacy `#watchlists` export. Returns null when the sentinel is
+ * absent, i.e. this is not that format and the caller should try another.
  */
 export function parseWatchlistsExport(text: string): NamedWatchlist[] | null {
   const lines = text.split(/\r?\n/);
@@ -106,12 +61,190 @@ export function parseWatchlistsExport(text: string): NamedWatchlist[] | null {
   const out: NamedWatchlist[] = [];
   for (const line of lines.slice(first + 1)) {
     if (!line.trim()) continue;
-    const [rawName, rest] = splitNameAndRest(line.trim());
+    const [rawName, ...rest] = parseCsvLine(line.trim());
     const name = sanitizeWatchlistName(rawName);
     if (!name) continue;
     out.push({ name, symbols: parseSymbolList(rest).valid });
   }
   return out;
+}
+
+// --- Spreadsheet CSV export ------------------------------------------------
+
+/**
+ * Column order of the export. Ticker first (leftmost), then which list it is
+ * on, then the market data the watchlist cards show. Price columns are blank
+ * when the provider has no data for that symbol.
+ */
+export const WATCHLIST_CSV_COLUMNS = [
+  'Symbol',
+  'List',
+  'Price',
+  'Change',
+  'Change %',
+  '1D %',
+  '5D %',
+  '30D %',
+  'Open',
+  'High',
+  'Low',
+  'Prev Close',
+  'Volume',
+  'As Of',
+] as const;
+
+/** Market data for one exported row; every field is optional. */
+export interface WatchlistCsvQuote {
+  price?: number;
+  change?: number;
+  changePercent?: number;
+  previousClose?: number;
+  open?: number;
+  high?: number;
+  low?: number;
+  volume?: number;
+  /** UTC unix seconds of the latest bar. */
+  asOf?: number;
+}
+
+/** Trailing % changes for one exported row. */
+export interface WatchlistCsvChanges {
+  d1?: number | null;
+  d5?: number | null;
+  d30?: number | null;
+}
+
+export interface WatchlistCsvData {
+  quotes?: Record<string, WatchlistCsvQuote | undefined>;
+  changes?: Record<string, WatchlistCsvChanges | undefined>;
+}
+
+/** Escape one CSV field (RFC4180: quote when it holds a comma, quote or newline). */
+function csvField(value: string): string {
+  return /["\n\r,]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+/** Split one CSV line into fields, honoring quoted fields and `""` escapes. */
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let field = '';
+  let quoted = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (quoted) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') {
+          field += '"';
+          i += 1;
+        } else {
+          quoted = false;
+        }
+      } else {
+        field += ch;
+      }
+    } else if (ch === '"' && field.length === 0) {
+      quoted = true;
+    } else if (ch === ',') {
+      fields.push(field);
+      field = '';
+    } else {
+      field += ch;
+    }
+  }
+  fields.push(field);
+  return fields;
+}
+
+/** Fixed-decimal cell, blank when the value is missing or non-finite. */
+function num(value: number | null | undefined, decimals = 2): string {
+  return typeof value === 'number' && Number.isFinite(value) ? value.toFixed(decimals) : '';
+}
+
+/** Unix seconds -> `YYYY-MM-DD`, blank when absent. */
+function asOfDate(seconds: number | undefined): string {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds)) return '';
+  const iso = new Date(seconds * 1000).toISOString();
+  return iso.slice(0, 10);
+}
+
+/**
+ * Render lists as a spreadsheet-friendly CSV: a header row, then one row per
+ * ticker with the symbol leftmost and its live market data alongside. Lists
+ * are grouped by name and tickers within each are alphabetical. An empty list
+ * still gets a row (blank symbol) so it survives a round trip.
+ */
+export function formatWatchlistsCsv(lists: NamedWatchlist[], data: WatchlistCsvData = {}): string {
+  const rows: string[] = [WATCHLIST_CSV_COLUMNS.join(',')];
+
+  for (const list of [...lists].sort((a, b) => a.name.localeCompare(b.name))) {
+    const symbols = formatSymbolsCsv(list.symbols);
+    if (!symbols) {
+      rows.push(`,${csvField(list.name)}`);
+      continue;
+    }
+    for (const symbol of symbols.split(',')) {
+      const q = data.quotes?.[symbol];
+      const c = data.changes?.[symbol];
+      rows.push(
+        [
+          symbol,
+          csvField(list.name),
+          num(q?.price),
+          num(q?.change),
+          num(q?.changePercent),
+          num(c?.d1),
+          num(c?.d5),
+          num(c?.d30),
+          num(q?.open),
+          num(q?.high),
+          num(q?.low),
+          num(q?.previousClose),
+          num(q?.volume, 0),
+          asOfDate(q?.asOf),
+        ].join(','),
+      );
+    }
+  }
+
+  return rows.join('\n');
+}
+
+/**
+ * Parse the spreadsheet CSV back into lists, keyed off the `Symbol` / `List`
+ * header columns — price columns are ignored, so a file edited in a
+ * spreadsheet still imports. Returns null when the header isn't ours, leaving
+ * the caller to fall back to a plain ticker list.
+ *
+ * `fallbackName` names rows whose `List` cell is blank (or when the file has
+ * no `List` column at all) — callers pass the file name.
+ */
+export function parseWatchlistsCsv(text: string, fallbackName: string): NamedWatchlist[] | null {
+  const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  if (lines.length === 0) return null;
+
+  const header = parseCsvLine(lines[0]).map((h) => h.trim().toLowerCase());
+  const symbolAt = header.indexOf('symbol');
+  if (symbolAt === -1) return null;
+  const listAt = header.indexOf('list');
+
+  const order: string[] = [];
+  const bySymbolList = new Map<string, { name: string; symbols: string[] }>();
+
+  for (const line of lines.slice(1)) {
+    const fields = parseCsvLine(line);
+    const name = sanitizeWatchlistName(listAt === -1 ? fallbackName : fields[listAt]) ?? fallbackName;
+    const key = name.toLowerCase();
+    let entry = bySymbolList.get(key);
+    if (!entry) {
+      entry = { name, symbols: [] };
+      bySymbolList.set(key, entry);
+      order.push(key);
+    }
+    const symbol = parseSymbolList(fields[symbolAt] ?? '').valid[0];
+    if (symbol && !entry.symbols.includes(symbol)) entry.symbols.push(symbol);
+  }
+
+  return order.map((key) => bySymbolList.get(key) as NamedWatchlist);
 }
 
 /** File name for an exported list, e.g. "My Tech List" -> "my-tech-list.csv". */


### PR DESCRIPTION
Export (single list and all lists) now writes a spreadsheet-shaped CSV: a header row, then one row per stock with the **symbol leftmost** and its market data alongside.

```
Symbol,List,Price,Change,Change %,1D %,5D %,30D %,Open,High,Low,Prev Close,Volume,As Of
XOM,Energy,98.10,0.44,0.45,0.45,1.20,-2.10,97.80,98.40,97.55,97.66,12345600,2026-08-01
AAPL,Tech,123.46,-1.20,-0.96,-0.96,2.12,,124.00,125.00,122.50,124.66,54321000,2026-08-01
```

- Prices come from `/api/finance/quotes` + `/api/finance/watchlist/changes`, fetched in 60-symbol chunks since both routes cap a request there. A failed chunk leaves those cells blank rather than sinking the file.
- Import reads the `Symbol` / `List` columns back, ignores price columns and tolerates extra ones, so a file edited in a spreadsheet still restores. Blank `List` cell (or no `List` column) falls back to the file name.
- Files in the previous `#watchlists` format still import.
- Lists are grouped and sorted by name; tickers alphabetical within each. An empty list keeps a blank-symbol row so it survives a round trip.

Helpers are pure and unit-tested (39 tests in `watchlist.test.ts`). No API or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)