### PR TITLE
fix(radio): keep the stream alive when volume changes

### DIFF
--- a/src/components/radio/radio-player-modal.test.tsx
+++ b/src/components/radio/radio-player-modal.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Radio Player Modal — volume independence
+ *
+ * Regression coverage for the stream restarting whenever the volume slider
+ * moved: the stream-attach effect used to list `volume`/`isMuted` in its
+ * dependencies, so each slider tick destroyed the HLS instance (or reset
+ * `audio.src`) and the station buffered from scratch.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { RadioStream } from '@/hooks/use-radio';
+
+const hlsInstances: Array<{ loadSource: ReturnType<typeof vi.fn>; destroy: ReturnType<typeof vi.fn> }> = [];
+
+vi.mock('hls.js', () => {
+  class MockHls {
+    static Events = { MANIFEST_PARSED: 'hlsManifestParsed', ERROR: 'hlsError' };
+    static isSupported = (): boolean => true;
+
+    loadSource = vi.fn();
+    attachMedia = vi.fn();
+    on = vi.fn();
+    destroy = vi.fn();
+
+    constructor() {
+      hlsInstances.push(this);
+    }
+  }
+  return { default: MockHls };
+});
+
+let mockStream: RadioStream | null = null;
+
+vi.mock('@/hooks/use-radio', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks/use-radio')>();
+  return {
+    ...actual,
+    useRadioStream: (): {
+      preferredStream: RadioStream | null;
+      isLoading: boolean;
+      error: string | null;
+      getStream: () => Promise<void>;
+    } => ({
+      preferredStream: mockStream,
+      isLoading: false,
+      error: null,
+      getStream: vi.fn().mockResolvedValue(undefined),
+    }),
+  };
+});
+
+vi.mock('@/lib/media-session', () => ({
+  setMediaSessionMetadata: vi.fn(),
+  updateMediaSessionPlaybackState: vi.fn(),
+  setMediaSessionActionHandlers: vi.fn(),
+  clearMediaSession: vi.fn(),
+}));
+
+const { RadioPlayerModal } = await import('./radio-player-modal');
+
+const station = { id: 'st-1', name: 'Test FM' };
+
+const renderPlayer = (): HTMLInputElement => {
+  render(<RadioPlayerModal station={station} isOpen onClose={vi.fn()} />);
+  return screen.getByLabelText('Volume') as HTMLInputElement;
+};
+
+const audioEl = (): HTMLAudioElement =>
+  document.querySelector('audio') as HTMLAudioElement;
+
+beforeEach(() => {
+  hlsInstances.length = 0;
+  vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+  vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+  vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
+});
+
+describe('RadioPlayerModal volume', () => {
+  it('changes element volume without re-attaching a direct stream', () => {
+    mockStream = { url: 'https://cdn.example.com/stream.mp3', mediaType: 'mp3', isDirect: true };
+
+    const slider = renderPlayer();
+    const audio = audioEl();
+    expect(audio.src).toContain('stream.mp3');
+
+    const loadCallsBefore = (HTMLMediaElement.prototype.load as ReturnType<typeof vi.fn>).mock
+      .calls.length;
+
+    fireEvent.change(slider, { target: { value: '0.3' } });
+
+    expect(audio.volume).toBeCloseTo(0.3);
+    expect(audio.src).toContain('stream.mp3');
+    // A re-attach would tear the src down and call load() in the cleanup.
+    expect(
+      (HTMLMediaElement.prototype.load as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBe(loadCallsBefore);
+  });
+
+  it('does not rebuild the HLS instance when the volume changes', () => {
+    mockStream = { url: 'https://cdn.example.com/live.m3u8', mediaType: 'hls', isDirect: false };
+
+    const slider = renderPlayer();
+    expect(hlsInstances).toHaveLength(1);
+
+    fireEvent.change(slider, { target: { value: '0.5' } });
+    fireEvent.change(slider, { target: { value: '0.2' } });
+
+    expect(hlsInstances).toHaveLength(1);
+    expect(hlsInstances[0]?.destroy).not.toHaveBeenCalled();
+    expect(audioEl().volume).toBeCloseTo(0.2);
+  });
+
+  it('mutes and unmutes without re-attaching the stream', () => {
+    mockStream = { url: 'https://cdn.example.com/live.m3u8', mediaType: 'hls', isDirect: false };
+
+    renderPlayer();
+    const audio = audioEl();
+
+    fireEvent.click(screen.getByLabelText('Mute'));
+    expect(audio.volume).toBe(0);
+
+    fireEvent.click(screen.getByLabelText('Unmute'));
+    expect(audio.volume).toBeCloseTo(0.8);
+
+    expect(hlsInstances).toHaveLength(1);
+    expect(hlsInstances[0]?.destroy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/radio/radio-player-modal.tsx
+++ b/src/components/radio/radio-player-modal.tsx
@@ -78,7 +78,6 @@ export function RadioPlayerModal({
     if (!preferredStream || !audioRef.current || !isOpen) return;
 
     const audio = audioRef.current;
-    audio.volume = isMuted ? 0 : volume;
 
     const isHls =
       preferredStream.mediaType === 'hls' ||
@@ -120,7 +119,15 @@ export function RadioPlayerModal({
       audio.removeAttribute('src');
       audio.load();
     };
-  }, [preferredStream, isOpen, volume, isMuted]);
+    // Volume/mute are applied by the effect below so changing them never
+    // re-attaches the stream.
+  }, [preferredStream, isOpen]);
+
+  // Apply volume/mute to the element without touching the stream
+  useEffect(() => {
+    if (!audioRef.current) return;
+    audioRef.current.volume = isMuted ? 0 : volume;
+  }, [volume, isMuted, isOpen]);
 
   // Cleanup on close
   useEffect(() => {
@@ -225,22 +232,14 @@ export function RadioPlayerModal({
   const handleVolumeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>): void => {
     const newVolume = parseFloat(e.target.value);
     setVolume(newVolume);
-    if (audioRef.current) {
-      audioRef.current.volume = isMuted ? 0 : newVolume;
-    }
-    if (newVolume > 0 && isMuted) {
+    if (newVolume > 0) {
       setIsMuted(false);
     }
-  }, [isMuted]);
+  }, []);
 
   const toggleMute = useCallback((): void => {
-    setIsMuted((prev) => {
-      if (audioRef.current) {
-        audioRef.current.volume = prev ? volume : 0;
-      }
-      return !prev;
-    });
-  }, [volume]);
+    setIsMuted((prev) => !prev);
+  }, []);
 
   const handleAudioPlay = useCallback((): void => {
     setIsPlaying(true);


### PR DESCRIPTION
## Problem

Changing the volume in the live radio player restarted the stream. Each slider tick caused an audible gap and re-buffer.

## Cause

`src/components/radio/radio-player-modal.tsx` applied volume inside the stream-attach effect, so `volume` and `isMuted` were in its dependency array:

```js
}, [preferredStream, isOpen, volume, isMuted]);
```

Every change re-ran the effect's cleanup — `hls.destroy()` for HLS stations, `removeAttribute('src')` + `load()` for MP3/AAC — and re-attached the station from scratch.

## Fix

Volume and mute now apply to the media element in their own effect. The attach effect re-runs only when the stream or open state actually changes. The handlers are pure state updates instead of also mutating the element directly — the mute toggle was previously mutating inside a `setState` updater, which double-fires under StrictMode.

## Tests

Three regression tests in `radio-player-modal.test.tsx` cover the direct-stream path, the HLS path, and mute/unmute. All three fail against the old dependency array and pass with the fix.

Full suite: 184 files, 2551 passed. `typecheck` and `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)