### PR TITLE
fix(finance): accept BOM-prefixed watchlist CSVs

### DIFF
--- a/src/lib/finance/watchlist.test.ts
+++ b/src/lib/finance/watchlist.test.ts
@@ -168,6 +168,12 @@ describe('parseWatchlistsCsv', () => {
     ]);
   });
 
+  it('recognizes a UTF-8 byte order mark before the header', () => {
+    expect(parseWatchlistsCsv('\uFEFFSymbol,List\nAAPL,Tech\n', 'ignored')).toEqual([
+      { name: 'Tech', symbols: ['AAPL'] },
+    ]);
+  });
+
   it('returns null for a plain ticker list, so it imports as a single list', () => {
     expect(parseWatchlistsCsv('AAPL,NVDA,SPY', 'f')).toBeNull();
     expect(parseWatchlistsCsv('AAPL\nNVDA', 'f')).toBeNull();
@@ -201,6 +207,10 @@ describe('parseWatchlistsExport (legacy #watchlists files)', () => {
 
   it('tolerates blank lines and CRLF', () => {
     expect(parseWatchlistsExport('#watchlists\r\n\r\nTech,AAPL\r\n')).toEqual([{ name: 'Tech', symbols: ['AAPL'] }]);
+  });
+
+  it('recognizes a UTF-8 byte order mark before the sentinel', () => {
+    expect(parseWatchlistsExport('\uFEFF#watchlists\nTech,AAPL')).toEqual([{ name: 'Tech', symbols: ['AAPL'] }]);
   });
 });
 

--- a/src/lib/finance/watchlist.ts
+++ b/src/lib/finance/watchlist.ts
@@ -6,6 +6,10 @@ import { normalizeSymbol } from './market-data/stooq';
 
 const SYMBOL_RE = /^[A-Z][A-Z0-9.\-]{0,9}$/;
 
+function stripByteOrderMark(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
 /** Max length for a watchlist name. */
 export const MAX_WATCHLIST_NAME = 60;
 
@@ -54,7 +58,7 @@ export interface NamedWatchlist {
  * absent, i.e. this is not that format and the caller should try another.
  */
 export function parseWatchlistsExport(text: string): NamedWatchlist[] | null {
-  const lines = text.split(/\r?\n/);
+  const lines = stripByteOrderMark(text).split(/\r?\n/);
   const first = lines.findIndex((line) => line.trim().length > 0);
   if (first === -1 || lines[first].trim().toLowerCase() !== WATCHLISTS_EXPORT_HEADER) return null;
 
@@ -219,7 +223,9 @@ export function formatWatchlistsCsv(lists: NamedWatchlist[], data: WatchlistCsvD
  * no `List` column at all) — callers pass the file name.
  */
 export function parseWatchlistsCsv(text: string, fallbackName: string): NamedWatchlist[] | null {
-  const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  const lines = stripByteOrderMark(text)
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0);
   if (lines.length === 0) return null;
 
   const header = parseCsvLine(lines[0]).map((h) => h.trim().toLowerCase());


### PR DESCRIPTION
## Description

- strips a leading UTF-8 BOM before detecting watchlist CSV headers
- applies the same normalization to legacy `#watchlists` exports
- prevents BOM-prefixed spreadsheet files from falling back to the plain ticker parser

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Submission Payout

- [ ] PR: $100 minimum per accepted PR
- [x] Bug fix: $100 minimum per confirmed bug fix
- [ ] QA run: $250 minimum per QA run (files bugs and/or fixes them)
- [ ] Feature/fix: $100 minimum per accepted feature implementation or substantive fix

## TDD Checklist (MANDATORY)

- [ ] Tests written FIRST (before implementation)
- [x] All new code has corresponding tests
- [ ] All tests pass locally (`pnpm test`)
- [x] Edge cases are covered
- [x] No `any` types used
- [ ] TypeScript strict mode passes (`pnpm tsc --noEmit`)
- [ ] ESLint passes (`pnpm lint`)

## Security Checklist

- [x] No Supabase calls from client-side code
- [x] No sensitive data exposed in client bundle
- [x] Input normalization implemented
- [x] Rate limiting not applicable

## Testing

### Test Coverage

- Number of new tests: 2
- Test file modified: `src/lib/finance/watchlist.test.ts`
- Focused result: 41/41 watchlist tests pass
- Focused TypeScript check passes for `watchlist.ts`
- `git diff --check` passes

### How to Test

1. Import a CSV beginning with `\uFEFFSymbol,List` and an `AAPL,Tech` row.
2. Confirm it creates a `Tech` list containing only `AAPL`.
3. Repeat with a BOM-prefixed legacy `#watchlists` export.

## Related Issues

Closes #167

## Additional Notes

A fresh full install was not used because local supply-chain policy rejected a committed Git dependency without lockfile integrity; the policy was not bypassed. Focused tests ran against an existing verified dependency set.