### PR TITLE
fix(seedbox): reopen the dead rental link, and scope a pass to what the seedbox confirms

### DIFF
--- a/docs/prds/seedbox-pay-per-watch.md
+++ b/docs/prds/seedbox-pay-per-watch.md
@@ -111,7 +111,8 @@ This is what a pass may stream. A pass can only reach files whose torrent it add
 | `grant_id` | uuid → `seedbox_share_grants(id)` ON DELETE CASCADE | |
 | `share_id` | uuid → `seedbox_shares(id)` ON DELETE CASCADE | |
 | `infohash` | text | parsed from magnet; matches torlink `/status` |
-| `name` | text NULL | torrent display name / top-level dir (from torlink status) |
+| `name` | text NULL | torrent display name / top-level dir |
+| `name_verified` | boolean | true only once `name` came from torlink `/status` |
 | `magnet` | text | the submitted magnet (validated) |
 | `status` | text | `added` \| `downloading` \| `complete` \| `error` (best-effort) |
 | `created_at` / `updated_at` | timestamptz | |
@@ -120,6 +121,14 @@ Indexes on `grant_id`, `share_id`, `(grant_id, infohash)` unique. RLS: service-r
 **Streaming scope:** a requested file `path` is allowed for a pass iff its top-level segment
 matches the `name` of one of that grant's `seedbox_share_downloads` rows (torlink saves each
 torrent under its name). `buildSeedboxFileUrl` still blocks traversal on top of this.
+
+**Only verified names grant scope.** A row's `name` starts as the magnet's `dn`, which the
+renter chooses — so it is a display label until torlink reports a name for that infohash and
+`name_verified` flips true. Authorizing on an unverified name would let a paid pass submit
+`dn=<a folder already on the owner's box>` and stream the owner's own library. Until a
+download is verified it has no scope: `/stream` 403s and the file listing returns empty.
+Directory listings go through `buildSeedboxDirUrl`, which rejects traversal the same way —
+percent-encoding alone does not, since `encodeURIComponent('..')` is `'..'`.
 
 ## 5. API surface
 

--- a/src/app/seedboxes/rent-out.tsx
+++ b/src/app/seedboxes/rent-out.tsx
@@ -47,6 +47,28 @@ const STATUS_STYLE: Record<Rental['status'], string> = {
   closed: 'bg-red-500/10 text-red-500',
 };
 
+function hasLapsed(rental: Rental): boolean {
+  return !!rental.expiresAt && new Date(rental.expiresAt).getTime() <= Date.now();
+}
+
+/**
+ * What the public /rent page actually does with this rental. A lapsed
+ * `expiresAt` closes the link while the stored status stays 'active', so
+ * showing the raw status would tell the owner their dead link is fine.
+ */
+function effectiveStatus(rental: Rental): Rental['status'] {
+  if (rental.status === 'active' && hasLapsed(rental)) return 'expired';
+  return rental.status;
+}
+
+function fmtDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
 export function RentOut(): React.ReactElement {
   const [rentals, setRentals] = useState<Rental[]>([]);
   const [ready, setReady] = useState<ReadyState | null>(null);
@@ -60,7 +82,9 @@ export function RentOut(): React.ReactElement {
   const [price, setPrice] = useState('0.25');
   const [windowHours, setWindowHours] = useState('24');
   const [maxDownloads, setMaxDownloads] = useState('2');
-  const [expiryDays, setExpiryDays] = useState('7');
+  // Default to never: a lapsed rental silently stops taking payments, and an
+  // owner who wants a deadline can still set one.
+  const [expiryDays, setExpiryDays] = useState('0');
   const [payoutWallet, setPayoutWallet] = useState('');
   const [payoutChain, setPayoutChain] = useState('SOL');
 
@@ -114,16 +138,21 @@ export function RentOut(): React.ReactElement {
     }
   }, [title, price, windowHours, maxDownloads, expiryDays, payoutWallet, payoutChain, load]);
 
-  const patchStatus = useCallback(
-    async (id: string, status: Rental['status']): Promise<void> => {
+  const patchRental = useCallback(
+    async (id: string, patch: Record<string, unknown>): Promise<void> => {
       await fetch(`/api/seedbox/shares/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status }),
+        body: JSON.stringify(patch),
       });
       await load();
     },
     [load]
+  );
+
+  const patchStatus = useCallback(
+    (id: string, status: Rental['status']): Promise<void> => patchRental(id, { status }),
+    [patchRental]
   );
 
   const remove = useCallback(
@@ -209,7 +238,7 @@ export function RentOut(): React.ReactElement {
               />
             </div>
             <div>
-              <label className={labelCls}>Auto-expire (days, 0 = never)</label>
+              <label className={labelCls}>Auto-expire (days, 0 = never — recommended)</label>
               <input
                 className={inputCls}
                 type="number"
@@ -256,14 +285,17 @@ export function RentOut(): React.ReactElement {
         {rentals.length === 0 && (
           <p className="text-sm text-text-secondary">No rentals yet.</p>
         )}
-        {rentals.map((r) => (
+        {rentals.map((r) => {
+          const status = effectiveStatus(r);
+          const lapsed = hasLapsed(r);
+          return (
           <div key={r.id} className="rounded-lg border border-border bg-bg-secondary p-4">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div className="min-w-0">
                 <div className="flex items-center gap-2">
                   <span className="font-medium text-text-primary">{r.title}</span>
-                  <span className={cn('rounded px-2 py-0.5 text-xs font-medium', STATUS_STYLE[r.status])}>
-                    {r.status}
+                  <span className={cn('rounded px-2 py-0.5 text-xs font-medium', STATUS_STYLE[status])}>
+                    {status}
                   </span>
                 </div>
                 <p className="mt-1 text-xs text-text-secondary">
@@ -272,6 +304,25 @@ export function RentOut(): React.ReactElement {
                   {r.sessionCount} session{r.sessionCount === 1 ? '' : 's'} · $
                   {r.earningsUsd.toFixed(2)} earned
                 </p>
+                <p className="mt-1 text-xs text-text-tertiary">
+                  {r.expiresAt
+                    ? `${lapsed ? 'Auto-expired' : 'Auto-expires'} ${fmtDate(r.expiresAt)}`
+                    : 'No auto-expiry'}
+                  {r.expiresAt ? (
+                    <button
+                      className="ml-2 text-accent-primary hover:underline"
+                      onClick={() => void patchRental(r.id, { expiresAt: null })}
+                    >
+                      remove expiry
+                    </button>
+                  ) : null}
+                </p>
+                {lapsed && r.status === 'active' ? (
+                  <p className="mt-2 rounded-md border border-yellow-500/30 bg-yellow-500/5 px-3 py-2 text-xs text-yellow-600">
+                    This link stopped taking payments when it expired. Reopen it to start
+                    renting again.
+                  </p>
+                ) : null}
                 <button
                   className="mt-2 inline-flex items-center gap-1 text-xs text-accent-primary hover:underline"
                   onClick={() => copyLink(r.slug)}
@@ -281,12 +332,20 @@ export function RentOut(): React.ReactElement {
                 </button>
               </div>
               <div className="flex shrink-0 items-center gap-2">
-                {r.status === 'active' && (
+                {lapsed && r.status !== 'closed' && (
+                  <button
+                    className={cn(btn, 'bg-accent-primary text-white hover:opacity-90')}
+                    onClick={() => void patchRental(r.id, { status: 'active', expiresAt: null })}
+                  >
+                    Reopen
+                  </button>
+                )}
+                {status === 'active' && (
                   <button className={cn(btn, 'bg-bg-hover text-text-primary')} onClick={() => void patchStatus(r.id, 'paused')}>
                     Pause
                   </button>
                 )}
-                {r.status === 'paused' && (
+                {r.status === 'paused' && !lapsed && (
                   <button className={cn(btn, 'bg-bg-hover text-text-primary')} onClick={() => void patchStatus(r.id, 'active')}>
                     Resume
                   </button>
@@ -306,7 +365,8 @@ export function RentOut(): React.ReactElement {
               </div>
             </div>
           </div>
-        ))}
+          );
+        })}
       </section>
     </div>
   );

--- a/src/lib/seedbox/files.test.ts
+++ b/src/lib/seedbox/files.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import type { SeedboxFilesConfig } from './config';
-import { buildSeedboxFileUrl, filesAuthHeaders } from './files';
+import { buildSeedboxDirUrl, buildSeedboxFileUrl, filesAuthHeaders } from './files';
 
 function cfg(overrides: Partial<SeedboxFilesConfig> = {}): SeedboxFilesConfig {
   return { baseUrl: 'http://box.example.com:9160', auth: { kind: 'none' }, ...overrides };
@@ -23,6 +23,26 @@ describe('buildSeedboxFileUrl', () => {
     expect(buildSeedboxFileUrl('http://box', 'http://evil.com/x')).toBeNull();
     expect(buildSeedboxFileUrl('http://box', 'a\\b')).toBeNull();
     expect(buildSeedboxFileUrl('http://box', '')).toBeNull();
+  });
+});
+
+describe('buildSeedboxDirUrl', () => {
+  it('returns the files root for an empty directory', () => {
+    expect(buildSeedboxDirUrl('http://box:9160', '')).toBe('http://box:9160/');
+    expect(buildSeedboxDirUrl('http://box:9160/', '  ')).toBe('http://box:9160/');
+  });
+  it('encodes segments and keeps the trailing slash a listing needs', () => {
+    expect(buildSeedboxDirUrl('http://box:9160', 'Movie (1999)/Subs')).toBe(
+      'http://box:9160/Movie%20(1999)/Subs/'
+    );
+  });
+  it('rejects traversal — encoding alone would leave `..` intact', () => {
+    expect(buildSeedboxDirUrl('http://box', '..')).toBeNull();
+    expect(buildSeedboxDirUrl('http://box', '../..')).toBeNull();
+    expect(buildSeedboxDirUrl('http://box', 'Movies/../../etc')).toBeNull();
+    expect(buildSeedboxDirUrl('http://box', '/etc')).toBeNull();
+    expect(buildSeedboxDirUrl('http://box', 'http://evil.com')).toBeNull();
+    expect(buildSeedboxDirUrl('http://box', 'a\\b')).toBeNull();
   });
 });
 

--- a/src/lib/seedbox/files.ts
+++ b/src/lib/seedbox/files.ts
@@ -63,11 +63,15 @@ export async function listOnDiskNames(
 }
 
 /**
- * Build the absolute seedbox URL for a torrent-relative file path. Returns null
- * for paths that try to escape the base (traversal / absolute / scheme).
+ * Split a base-relative path into safe segments, or null when it tries to
+ * escape the base (traversal / absolute / scheme / backslash).
+ *
+ * Every URL we build against a files server goes through this: encoding alone
+ * is not enough, because `encodeURIComponent('..')` is `'..'` and the server
+ * (or fetch) resolves it away, walking out of the seedbox save directory.
  */
-export function buildSeedboxFileUrl(baseUrl: string, filePath: string): string | null {
-  const trimmed = filePath.trim();
+export function safePathSegments(relPath: string): string[] | null {
+  const trimmed = relPath.trim();
   if (!trimmed) return null;
   // Reject absolute paths, schemes, backslashes, and traversal.
   if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null; // has a URL scheme
@@ -75,10 +79,34 @@ export function buildSeedboxFileUrl(baseUrl: string, filePath: string): string |
   if (trimmed.includes('\\')) return null;
 
   const segments = trimmed.split('/').filter((s) => s.length > 0);
+  if (segments.length === 0) return null;
   if (segments.some((s) => s === '..' || s === '.')) return null;
+  return segments;
+}
+
+/**
+ * Build the absolute seedbox URL for a torrent-relative file path. Returns null
+ * for paths that try to escape the base (traversal / absolute / scheme).
+ */
+export function buildSeedboxFileUrl(baseUrl: string, filePath: string): string | null {
+  const segments = safePathSegments(filePath);
+  if (!segments) return null;
 
   const encoded = segments.map((s) => encodeURIComponent(s)).join('/');
   return `${baseUrl.replace(/\/+$/, '')}/${encoded}`;
+}
+
+/**
+ * Build the absolute seedbox URL for a directory listing. An empty `relDir`
+ * means the files root; anything else is validated like a file path. Returns
+ * null when the path would escape the base.
+ */
+export function buildSeedboxDirUrl(baseUrl: string, relDir: string): string | null {
+  const base = baseUrl.replace(/\/+$/, '');
+  if (!relDir.trim()) return `${base}/`;
+  const segments = safePathSegments(relDir);
+  if (!segments) return null;
+  return `${base}/${segments.map((s) => encodeURIComponent(s)).join('/')}/`;
 }
 
 export interface SeedboxFetchOptions {

--- a/src/lib/seedbox/shares/index.ts
+++ b/src/lib/seedbox/shares/index.ts
@@ -24,6 +24,7 @@ export {
   deleteRental,
   getRentalActivity,
   isShareOpen,
+  isShareAcceptingDownloads,
   toPublicShare,
   getPublicShare,
   isShareOwnedBy,

--- a/src/lib/seedbox/shares/repository.ts
+++ b/src/lib/seedbox/shares/repository.ts
@@ -72,6 +72,7 @@ function toDownload(row: ShareRow): SeedboxShareDownload {
     shareId: String(row.share_id),
     infohash: String(row.infohash),
     name: (row.name as string | null) ?? null,
+    nameVerified: row.name_verified === true,
     magnet: String(row.magnet),
     status: row.status as DownloadStatus,
     createdAt: String(row.created_at),
@@ -392,7 +393,10 @@ export async function insertDownload(record: {
         grant_id: record.grantId,
         share_id: record.shareId,
         infohash: record.infohash,
+        // The renter's magnet `dn` — a label only. Streaming scope waits for a
+        // name the owner's seedbox reports for this infohash.
         name: record.name,
+        name_verified: false,
         magnet: record.magnet,
         status: 'added',
       },
@@ -442,13 +446,19 @@ export async function countDownloadsByShare(shareId: string): Promise<number> {
   return count ?? 0;
 }
 
-/** Persist a torrent's learned name/status from torlink status polling. */
+/**
+ * Persist a torrent's learned name/status from torlink status polling.
+ *
+ * `nameVerified` must only ever be set by a caller that read the name off the
+ * owner's seedbox — it is what authorizes playback.
+ */
 export async function updateDownloadMeta(
   id: string,
-  fields: { name?: string | null; status?: DownloadStatus }
+  fields: { name?: string | null; status?: DownloadStatus; nameVerified?: boolean }
 ): Promise<void> {
   const record: Record<string, unknown> = {};
   if (fields.name !== undefined) record.name = fields.name;
+  if (fields.nameVerified !== undefined) record.name_verified = fields.nameVerified;
   if (fields.status !== undefined) record.status = fields.status;
   if (Object.keys(record).length === 0) return;
   const { error } = await db().from('seedbox_share_downloads').update(record).eq('id', id);

--- a/src/lib/seedbox/shares/service.test.ts
+++ b/src/lib/seedbox/shares/service.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Seedbox-rental authorization tests.
+ *
+ * The rental flow hands an anonymous, paying stranger a pipe into someone
+ * else's box, so what a pass may reach is the part worth pinning down: scope
+ * comes from what the owner's seedbox confirms it downloaded, never from
+ * anything the renter typed.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SeedboxShare, SeedboxShareDownload, SeedboxShareGrant } from './types';
+
+vi.mock('./repository', () => ({
+  getShareBySlug: vi.fn(),
+  getGrantById: vi.fn(),
+  getDownloadById: vi.fn(),
+  listDownloadsByGrant: vi.fn(),
+  countDownloadsByGrant: vi.fn(),
+  insertDownload: vi.fn(),
+  updateDownloadMeta: vi.fn(),
+}));
+
+vi.mock('@/lib/seedbox', () => ({
+  isValidMagnet: vi.fn(() => true),
+  loadAccountSeedboxConfig: vi.fn(),
+  sendTorrentToSeedbox: vi.fn(async () => SEND_OK),
+}));
+
+vi.mock('@/lib/seedbox/stream', () => ({
+  streamSeedboxFile: vi.fn(async () => new Response('media', { status: 200 })),
+}));
+
+vi.mock('@/lib/coinpayportal/client', () => ({
+  getCoinPayPortalClient: vi.fn(),
+}));
+
+import { loadAccountSeedboxConfig, sendTorrentToSeedbox } from '@/lib/seedbox';
+import { streamSeedboxFile } from '@/lib/seedbox/stream';
+import { generateGrantToken, hashGrantToken } from './pass';
+import * as repo from './repository';
+import {
+  addDownload,
+  isShareAcceptingDownloads,
+  isShareOpen,
+  listDownloadFiles,
+  streamForPass,
+} from './service';
+
+const SEND_OK = { ok: true, transport: 'http' as const, message: 'added' };
+
+const SEEDBOX_CONFIG = {
+  http: {
+    baseUrl: 'http://box:9160',
+    token: 't',
+    addPath: '/add',
+    auth: { kind: 'bearer' as const },
+    magnetField: 'magnet',
+  },
+  ssh: null,
+  files: { baseUrl: 'http://box:8080', auth: { kind: 'none' as const } },
+};
+
+function share(overrides: Partial<SeedboxShare> = {}): SeedboxShare {
+  return {
+    id: 'share-1',
+    slug: 'abc123',
+    ownerAccountId: 'owner-1',
+    title: 'Rent my seedbox',
+    description: null,
+    priceUsd: 0.25,
+    passWindowMinutes: 1440,
+    maxDownloadsPerPass: 2,
+    maxDownloadSizeGb: null,
+    status: 'active',
+    expiresAt: null,
+    payoutWalletAddress: null,
+    payoutBlockchain: null,
+    viewCount: 0,
+    sessionCount: 0,
+    earningsUsd: 0,
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function grant(overrides: Partial<SeedboxShareGrant> = {}): SeedboxShareGrant {
+  return {
+    id: 'grant-1',
+    shareId: 'share-1',
+    coinpayportalPaymentId: 'pay-1',
+    grantTokenHash: 'hash',
+    status: 'paid',
+    amountUsd: 0.25,
+    expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    paidAt: '2026-08-01T00:00:00.000Z',
+    createdAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function download(overrides: Partial<SeedboxShareDownload> = {}): SeedboxShareDownload {
+  return {
+    id: 'dl-1',
+    grantId: 'grant-1',
+    shareId: 'share-1',
+    infohash: 'a'.repeat(40),
+    name: 'Some.Torrent.2026',
+    nameVerified: true,
+    magnet: 'magnet:?xt=urn:btih:' + 'a'.repeat(40),
+    status: 'complete',
+    createdAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const streamOpts = { method: 'GET' as const, range: null };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(loadAccountSeedboxConfig).mockResolvedValue(SEEDBOX_CONFIG);
+  vi.mocked(sendTorrentToSeedbox).mockResolvedValue(SEND_OK);
+});
+
+describe('streamForPass', () => {
+  it('streams a file under a name the seedbox confirmed', async () => {
+    vi.mocked(repo.listDownloadsByGrant).mockResolvedValue([download()]);
+
+    const res = await streamForPass(
+      share(),
+      grant(),
+      'Some.Torrent.2026/episode.mp4',
+      streamOpts
+    );
+
+    expect(res.status).toBe(200);
+    expect(streamSeedboxFile).toHaveBeenCalledWith(
+      SEEDBOX_CONFIG.files,
+      'Some.Torrent.2026/episode.mp4',
+      streamOpts
+    );
+  });
+
+  it('refuses a name that only ever came from the renter’s magnet', async () => {
+    // The renter paid, then submitted a magnet whose `dn` names a folder that
+    // already exists on the owner's box. Nothing confirmed that torrent, so the
+    // name must not open the owner's own library.
+    vi.mocked(repo.listDownloadsByGrant).mockResolvedValue([
+      download({ name: 'Movies', nameVerified: false, status: 'added' }),
+    ]);
+
+    const res = await streamForPass(share(), grant(), 'Movies/Owners.Film.mkv', streamOpts);
+
+    expect(res.status).toBe(403);
+    expect(streamSeedboxFile).not.toHaveBeenCalled();
+  });
+
+  it('refuses a file outside every download the pass owns', async () => {
+    vi.mocked(repo.listDownloadsByGrant).mockResolvedValue([download()]);
+
+    const res = await streamForPass(share(), grant(), 'Other.Torrent/x.mp4', streamOpts);
+
+    expect(res.status).toBe(403);
+    expect(streamSeedboxFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('listDownloadFiles', () => {
+  const token = generateGrantToken();
+  const cookie = `grant-1.${token}`;
+
+  beforeEach(() => {
+    vi.mocked(repo.getShareBySlug).mockResolvedValue(share());
+    vi.mocked(repo.getGrantById).mockResolvedValue(grant({ grantTokenHash: hashGrantToken(token) }));
+  });
+
+  it('lists nothing while the download name is still unconfirmed', async () => {
+    vi.mocked(repo.getDownloadById).mockResolvedValue(
+      download({ name: 'Movies', nameVerified: false, status: 'added' })
+    );
+
+    const result = await listDownloadFiles('abc123', cookie, 'dl-1');
+
+    expect(result).toEqual({ ok: true, files: [] });
+    // Never reached the owner's files server with a renter-chosen directory.
+    expect(loadAccountSeedboxConfig).not.toHaveBeenCalled();
+  });
+
+  it('rejects a download belonging to another pass', async () => {
+    vi.mocked(repo.getDownloadById).mockResolvedValue(download({ grantId: 'someone-else' }));
+
+    const result = await listDownloadFiles('abc123', cookie, 'dl-1');
+
+    expect(result).toEqual({ ok: false, status: 404, message: 'Download not found' });
+  });
+});
+
+describe('addDownload', () => {
+  const magnet = `magnet:?xt=urn:btih:${'b'.repeat(40)}&dn=My%20Torrent`;
+
+  beforeEach(() => {
+    vi.mocked(repo.countDownloadsByGrant).mockResolvedValue(0);
+    vi.mocked(repo.insertDownload).mockImplementation(async (record) => download(record));
+  });
+
+  it('stores the magnet’s name as an unverified label', async () => {
+    await addDownload(share(), grant(), magnet);
+
+    expect(repo.insertDownload).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'My Torrent', infohash: 'b'.repeat(40) })
+    );
+  });
+
+  it('strips path separators out of a hostile magnet name', async () => {
+    await addDownload(share(), grant(), `magnet:?xt=urn:btih:${'b'.repeat(40)}&dn=..%2F..%2Fetc`);
+
+    const record = vi.mocked(repo.insertDownload).mock.calls[0][0];
+    expect(record.name).not.toContain('/');
+    expect(record.name).not.toBe('..');
+  });
+
+  it('refuses new downloads once the owner pauses the rental', async () => {
+    await expect(addDownload(share({ status: 'paused' }), grant(), magnet)).rejects.toThrow(
+      /not accepting new downloads/
+    );
+    expect(sendTorrentToSeedbox).not.toHaveBeenCalled();
+  });
+
+  it('still accepts downloads on a pass bought before the link auto-expired', async () => {
+    const lapsed = share({ expiresAt: new Date(Date.now() - 86_400_000).toISOString() });
+    expect(isShareOpen(lapsed)).toBe(false); // no new passes sold
+    expect(isShareAcceptingDownloads(lapsed)).toBe(true); // but a paid pass isn't voided
+
+    await expect(addDownload(lapsed, grant(), magnet)).resolves.toBeTruthy();
+  });
+});

--- a/src/lib/seedbox/shares/service.ts
+++ b/src/lib/seedbox/shares/service.ts
@@ -17,7 +17,7 @@ import {
   sendTorrentToSeedbox,
 } from '@/lib/seedbox';
 import type { SeedboxConfig } from '@/lib/seedbox/config';
-import { filesAuthHeaders } from '@/lib/seedbox/files';
+import { buildSeedboxDirUrl, filesAuthHeaders } from '@/lib/seedbox/files';
 import { buildAuthHeaders } from '@/lib/seedbox/http-transport';
 import { streamSeedboxFile, type StreamOptions } from '@/lib/seedbox/stream';
 import { parseMagnet } from './magnet';
@@ -144,6 +144,18 @@ export function isShareOpen(share: SeedboxShare): boolean {
   if (share.status !== 'active') return false;
   if (share.expiresAt && new Date(share.expiresAt).getTime() <= Date.now()) return false;
   return true;
+}
+
+/**
+ * True when an already-paid pass may still add torrents.
+ *
+ * Deliberately weaker than {@link isShareOpen}: `expires_at` means "stop
+ * selling new passes", so someone who paid before it lapsed keeps the session
+ * they bought (their own grant expiry still bounds it). Pausing or closing is
+ * an explicit owner decision and does stop new downloads.
+ */
+export function isShareAcceptingDownloads(share: SeedboxShare): boolean {
+  return share.status === 'active';
 }
 
 export function toPublicShare(share: SeedboxShare): PublicShare {
@@ -320,11 +332,31 @@ export async function getGrantStatus(
 // Public: add a download under a pass
 // ---------------------------------------------------------------------------
 
+/**
+ * Reduce a renter-supplied magnet `dn` to a plain display label: no path
+ * separators, no control characters, bounded length. It never authorizes
+ * anything (see `name_verified`), but keeping it inert means a hostile `dn`
+ * can't be mistaken for a path anywhere downstream.
+ */
+function sanitizeDisplayName(raw: string | null): string | null {
+  if (!raw) return null;
+  const cleaned = raw
+    .replace(/[\x00-\x1f\x7f]/g, ' ')
+    .replace(/[/\\]/g, ' ')
+    .trim()
+    .slice(0, 300);
+  if (!cleaned || cleaned === '.' || cleaned === '..') return null;
+  return cleaned;
+}
+
 export async function addDownload(
   share: SeedboxShare,
   grant: SeedboxShareGrant,
   magnet: string
 ): Promise<SeedboxShareDownload> {
+  if (!isShareAcceptingDownloads(share)) {
+    throw new RentalError('This rental is not accepting new downloads right now', 403);
+  }
   if (!isValidMagnet(magnet)) {
     throw new RentalError('That doesn’t look like a valid magnet link', 400);
   }
@@ -355,7 +387,7 @@ export async function addDownload(
     grantId: grant.id,
     shareId: share.id,
     infohash: parsed.infohash,
-    name: parsed.name,
+    name: sanitizeDisplayName(parsed.name),
     magnet: magnet.trim(),
   });
 }
@@ -434,18 +466,30 @@ export async function listDownloadsWithProgress(
       : live
         ? 'downloading'
         : d.status;
-    const learnedName = live?.name && live.name !== '(unknown)' ? live.name : d.name;
+    // A name straight off the owner's seedbox, keyed by this download's
+    // infohash. This — and only this — is what may widen the pass's streaming
+    // scope, so it is tracked separately from the renter's magnet `dn` label.
+    const verifiedName = live?.name && live.name !== '(unknown)' ? live.name : null;
+    const displayName = verifiedName ?? d.name;
 
-    // Persist a learned name/status so streaming-scope checks work after the
-    // renter navigates away and back (best effort; ignore write failures).
-    if ((learnedName && learnedName !== d.name) || nextStatus !== d.status) {
-      repo.updateDownloadMeta(d.id, { name: learnedName ?? undefined, status: nextStatus }).catch(() => {});
+    // Persist it so scope checks still hold after the renter navigates away and
+    // back (best effort; ignore write failures).
+    const learnedName = verifiedName && verifiedName !== d.name ? verifiedName : undefined;
+    const newlyVerified = verifiedName != null && !d.nameVerified ? true : undefined;
+    if (learnedName !== undefined || newlyVerified !== undefined || nextStatus !== d.status) {
+      repo
+        .updateDownloadMeta(d.id, {
+          name: learnedName,
+          nameVerified: newlyVerified,
+          status: nextStatus,
+        })
+        .catch(() => {});
     }
 
     out.push({
       id: d.id,
       infohash: d.infohash,
-      name: learnedName ?? null,
+      name: displayName ?? null,
       status: nextStatus,
       progress,
       peers: live?.peers ?? 0,
@@ -474,6 +518,10 @@ function topSegment(filePath: string): string {
  * torlink saves each torrent under its `name`, so a file's top-level path
  * segment (or the whole single-file path) must match one of the grant's
  * download names.
+ *
+ * `names` must be seedbox-verified names only. The renter chooses the magnet's
+ * `dn`, so honouring an unverified name would let a $0.25 pass name any folder
+ * already sitting on the owner's box and stream the owner's own library.
  */
 function pathAllowedForGrant(filePath: string, names: string[]): boolean {
   const top = topSegment(filePath).toLowerCase();
@@ -491,7 +539,10 @@ export async function streamForPass(
   opts: StreamOptions
 ): Promise<Response> {
   const downloads = await repo.listDownloadsByGrant(grant.id);
-  const names = downloads.map((d) => d.name).filter((n): n is string => Boolean(n));
+  const names = downloads
+    .filter((d) => d.nameVerified)
+    .map((d) => d.name)
+    .filter((n): n is string => Boolean(n));
   if (names.length === 0 || !pathAllowedForGrant(filePath, names)) {
     return jsonError('That file isn’t part of your downloads', 403);
   }
@@ -537,13 +588,11 @@ async function listSeedboxDir(
   files: NonNullable<SeedboxConfig['files']>,
   relDir: string
 ): Promise<DirEntry[] | null> {
-  const base = files.baseUrl.replace(/\/+$/, '');
-  const encoded = relDir
-    .split('/')
-    .filter(Boolean)
-    .map((s) => encodeURIComponent(s))
-    .join('/');
-  const url = encoded ? `${base}/${encoded}/` : `${base}/`;
+  // Percent-encoding alone doesn't contain a path: `encodeURIComponent('..')`
+  // is `'..'`, which the upstream resolves away and walks out of the save
+  // directory. buildSeedboxDirUrl rejects traversal outright.
+  const url = buildSeedboxDirUrl(files.baseUrl, relDir);
+  if (!url) return null;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 6000);
   try {
@@ -598,8 +647,10 @@ export async function listDownloadFiles(
   if (!download || download.grantId !== pass.grant.id) {
     return { ok: false, status: 404, message: 'Download not found' };
   }
-  if (!download.name) {
-    return { ok: true, files: [] }; // torrent name not learned yet (still resolving)
+  // Until the owner's seedbox reports a name for this infohash we have no
+  // verified folder to open — and the magnet's `dn` must never be used as one.
+  if (!download.name || !download.nameVerified) {
+    return { ok: true, files: [] };
   }
 
   const config = await loadAccountSeedboxConfig(pass.share.ownerAccountId);

--- a/src/lib/seedbox/shares/types.ts
+++ b/src/lib/seedbox/shares/types.ts
@@ -61,7 +61,12 @@ export interface SeedboxShareDownload {
   grantId: string;
   shareId: string;
   infohash: string;
+  /** Display label. Starts as the renter-supplied magnet `dn`, so it is NOT
+   * trustworthy until {@link SeedboxShareDownload.nameVerified} is true. */
   name: string | null;
+  /** True once `name` came from the owner's seedbox (torlink `/status`) rather
+   * than the magnet. Only verified names grant streaming scope. */
+  nameVerified: boolean;
   magnet: string;
   status: DownloadStatus;
   createdAt: string;

--- a/supabase/migrations/20260809234500_seedbox_share_download_name_verified.sql
+++ b/supabase/migrations/20260809234500_seedbox_share_download_name_verified.sql
@@ -1,0 +1,20 @@
+-- Seedbox rentals: only a seedbox-verified torrent name may widen a pass's
+-- streaming scope.
+--
+-- A download's `name` was seeded from the magnet's `dn=` parameter, which the
+-- renter controls, and `name` is what authorizes playback (a pass may stream
+-- files whose top-level path segment matches one of its download names). So a
+-- renter could pay for a pass, submit a magnet carrying `dn=<a folder already
+-- on the owner's box>`, and read the owner's existing library — content they
+-- never downloaded.
+--
+-- `name_verified` separates the two roles the column was serving: the renter's
+-- `dn` stays a display label, and only a name learned from the owner's torlink
+-- `/status` (keyed by the infohash the torrent actually resolved to) grants
+-- streaming scope.
+
+ALTER TABLE seedbox_share_downloads
+  ADD COLUMN IF NOT EXISTS name_verified BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN seedbox_share_downloads.name_verified IS
+  'True only when `name` came from the owner''s seedbox (torlink /status), not from the renter-supplied magnet `dn`. Streaming scope is granted by verified names alone.';


### PR DESCRIPTION
## The reported symptom

The copied rental link showed **"Rent my seedbox — This rental is not currently available."**

There is one rental in prod (`/rent/id_Z-yuVJUOM`, $1.00). Its `status` was `active`, but its `expires_at` was **2026-07-27** — it was created on 2026-07-20 with the Rent Out form's default *Auto-expire: 7 days*, and `isShareOpen()` treats a lapsed `expires_at` as closed. So the paywall had been dead for 13 days. Five people hit checkout in that window; all five grants are still `pending`, so nobody could pay.

The owner had no way to see or fix this: the Rent Out tab renders the raw `status`, which still said **active** in green, and the UI has no control for changing an expiry after creation.

**Already fixed in prod (data):** `expires_at` cleared on that rental. `GET /api/public/shares/id_Z-yuVJUOM` now returns `"active": true`, so the page shows *Pay $1.00 to start*. **The migration in this PR is also already applied to prod**, so the column exists before this code deploys.

## The permission holes this turned up

Auditing what a paid pass can actually reach on the owner's box found two real problems. Both are server-side; neither depended on a modified client.

### 1. Scope came from a string the renter types

`seedbox_share_downloads.name` was seeded from the magnet's `dn=` parameter, and `name` is exactly what authorizes playback — `pathAllowedForGrant` allows a file whose top-level path segment matches one of the grant's download names.

So: pay $0.25, submit a magnet whose `dn` is a folder that already exists on the owner's seedbox (`dn=Movies`), and the pass could list and stream the **owner's own library** — content the renter never downloaded and never paid for. The magnet didn't even have to resolve.

`name_verified` splits the two jobs the column was doing. The renter's `dn` stays a display label; only a name the owner's torlink `/status` reports **for that infohash** flips `name_verified` and grants scope. An unverified download has no scope at all: `/stream` 403s and the file listing returns empty.

Verification is sticky, so a torrent that later drops out of `/status` doesn't lock out the renter who paid for it. And it fails closed in the same direction the UI already does — the Play list only appears once a download reports `ready`, which needs the same `/status` call.

### 2. Traversal in the directory listing

`listSeedboxDir` built its URL by percent-encoding each segment — but `encodeURIComponent('..')` is `'..'`, which the upstream resolves away. A `dn` of `../..` walked directory listings above the seedbox files root. (Streaming was already safe: `buildSeedboxFileUrl` rejects `..`.)

Listings now go through a new `buildSeedboxDirUrl`, sharing the traversal checks with the file path builder via `safePathSegments`.

## Also in here

- **New downloads stop when an owner pauses or closes** a rental. A pass bought *before* the link auto-expired keeps the session it paid for — `expires_at` means "stop selling", and the grant's own expiry still bounds it.
- Magnet `dn` is sanitized to an inert label (no path separators, no control chars, capped length).
- **Owner UI** shows the status the public page actually acts on (`expired`, not `active`), names the expiry date, explains that a lapsed link stopped taking payments, and offers **Reopen** and **remove expiry**.
- New rentals default to **no auto-expiry**.

## On "HTTP seed, no SSH"

Confirmed: this path never touches SSH. `addDownload` calls `sendTorrentToSeedbox(..., 'http', config)` explicitly, and playback proxies the owner's HTTP files server. `ownerSeedboxReady` requires exactly those two. The rental owner's account has both configured.

## Verification

- 3 of the new tests fail against the pre-fix code and pass after — they guard the actual holes, not just the new shape.
- `pnpm build` ✅ · `pnpm test` 2563 passed / 185 files ✅ · `pnpm typecheck` ✅ · `pnpm lint` 0 errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
