### PR TITLE
feat(layout): add Launchpadly badge to footer

### DIFF
--- a/src/components/layout/main-layout.tsx
+++ b/src/components/layout/main-layout.tsx
@@ -85,6 +85,26 @@ export function MainLayout({ children, className }: MainLayoutProps): React.Reac
           <a href="/privacy" className="hover:text-text-primary transition-colors">Privacy</a>
           <span className="mx-2">·</span>
           <a href="https://github.com/profullstack/media-streamer" target="_blank" rel="noopener noreferrer" className="hover:text-text-primary transition-colors">GitHub</a>
+
+          {/* Launchpadly badge */}
+          <div className="mt-3">
+            <a
+              href="https://launchpadly.co/startup/bittorrented?ref=badge"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block opacity-70 transition-opacity hover:opacity-100"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src="https://launchpadly.co/embed/badges/startup/bittorrented.svg?variant=dark"
+                alt="Launchpadly Startup Directory"
+                width={260}
+                height={48}
+                loading="lazy"
+                className="h-8 w-auto"
+              />
+            </a>
+          </div>
         </footer>
       </div>
     </div>


### PR DESCRIPTION
Adds the Launchpadly startup directory badge to the site footer, on its own row below the existing links.

**Placement:** own row under Terms / Privacy / GitHub, `mt-3`, 32px tall, `opacity-70` brightening to full on hover — visible without competing with the footer links.

**One deviation from the snippet as given:** switched `?variant=light` → `?variant=dark`. The light variant is a `#f8fafc` card, which renders as a bright white pill against this app's dark footer (`dark` is hardcoded on `<html>` in `src/app/layout.tsx`, no light mode). The dark variant (`#0a0f0d` with a green border) blends in. Flip the one word in the URL if the light card is preferred.

Plain `<img>` rather than `next/image` — the badge is an external SVG that would otherwise need a `remotePatterns` entry, and `<img>` is already used throughout the components.

## Verification
- `tsc --noEmit` — clean
- `eslint src/components/layout/main-layout.tsx` — clean
- Rendered against a local dev server: homepage returns 200 with both the badge `<img>` and the link present in the markup
- Badge URL returns `200 image/svg+xml`
- No global CSP restricts image sources (only `/api/player`'s sandbox CSP, which already allows `img-src *`)

No test covers the footer — `src/components/layout/*.test.tsx` are all in vitest's exclude list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)