### PR TITLE
Preserve literal percent signs in magnet parameters

### DIFF
--- a/src/lib/magnet/magnet.test.ts
+++ b/src/lib/magnet/magnet.test.ts
@@ -43,6 +43,16 @@ describe('Magnet URI Parser', () => {
       expect(result.displayName).toBe('My Awesome Torrent [2024]');
     });
 
+    it('should preserve encoded literal percents in decoded parameters', () => {
+      const magnetUri = 'magnet:?xt=urn:btih:1234567890abcdef1234567890abcdef12345678&dn=100%25ZZ&tr=https%3A%2F%2Ftracker.example%2F100%25ZZ&ws=https%3A%2F%2Fseed.example%2F100%25ZZ&kt=100%25ZZ';
+      const result = parseMagnetUri(magnetUri);
+
+      expect(result.displayName).toBe('100%ZZ');
+      expect(result.trackers).toEqual(['https://tracker.example/100%ZZ']);
+      expect(result.webSeeds).toEqual(['https://seed.example/100%ZZ']);
+      expect(result.keywords).toEqual(['100%ZZ']);
+    });
+
     it('should parse magnet URI with exact length (xl) parameter', () => {
       const magnetUri = 'magnet:?xt=urn:btih:1234567890abcdef1234567890abcdef12345678&xl=1073741824';
       const result = parseMagnetUri(magnetUri);

--- a/src/lib/magnet/magnet.ts
+++ b/src/lib/magnet/magnet.ts
@@ -136,13 +136,13 @@ export function parseMagnetUri(magnetUri: string): ParsedMagnet {
 
   // Extract display name (dn)
   const dn = params.get('dn');
-  const displayName = dn ? decodeURIComponent(dn.replace(/\+/g, ' ')) : undefined;
+  const displayName = dn || undefined;
 
   // Extract trackers (tr) - can have multiple
   const trackers: string[] = [];
   for (const [key, value] of params.entries()) {
     if (key === 'tr') {
-      trackers.push(decodeURIComponent(value));
+      trackers.push(value);
     }
   }
 
@@ -154,13 +154,13 @@ export function parseMagnetUri(magnetUri: string): ParsedMagnet {
   const webSeeds: string[] = [];
   for (const [key, value] of params.entries()) {
     if (key === 'ws') {
-      webSeeds.push(decodeURIComponent(value));
+      webSeeds.push(value);
     }
   }
 
   // Extract keywords (kt)
   const kt = params.get('kt');
-  const keywords = kt ? decodeURIComponent(kt).split(/\s+/) : [];
+  const keywords = kt ? kt.split(/\s+/) : [];
 
   return {
     infohash,

--- a/src/lib/torrent-index/torrent-index.test.ts
+++ b/src/lib/torrent-index/torrent-index.test.ts
@@ -55,6 +55,13 @@ describe('Torrent Index Module', () => {
       expect(result.name).toBe('My Awesome Torrent [2024]');
     });
 
+    it('should preserve an encoded literal percent in the display name', () => {
+      const magnet = 'magnet:?xt=urn:btih:abc123def456789012345678901234567890abcd&dn=100%25ZZ';
+      const result = parseMagnetUri(magnet);
+
+      expect(result.name).toBe('100%ZZ');
+    });
+
     it('should handle uppercase infohash', () => {
       const magnet = 'magnet:?xt=urn:btih:ABC123DEF456789012345678901234567890ABCD';
       const result = parseMagnetUri(magnet);

--- a/src/lib/torrent-index/torrent-index.ts
+++ b/src/lib/torrent-index/torrent-index.ts
@@ -208,7 +208,7 @@ export function parseMagnetUri(magnetUri: string): ParsedMagnet {
 
   // Get display name
   const dn = params.get('dn');
-  const name = dn ? decodeURIComponent(dn.replace(/\+/g, ' ')) : infohash;
+  const name = dn || infohash;
 
   // Get trackers
   const trackers: string[] = [];


### PR DESCRIPTION
## Description

Avoid decoding magnet query parameters twice. `URLSearchParams` already returns decoded values, so a valid literal percent such as `dn=100%25ZZ` previously became `100%ZZ` and then threw `URIError` during the second decode. Both shared parsers now preserve the decoded name, tracker, web-seed, and keyword values.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Submission Payout

- [ ] PR: $100 minimum per accepted PR
- [x] Bug fix: $100 minimum per confirmed bug fix
- [ ] QA run: $250 minimum per QA run (files bugs and/or fixes them)
- [ ] Feature/fix: $100 minimum per accepted feature implementation or substantive fix

## TDD Checklist (MANDATORY)

**All items must be checked before merge:**

- [x] Tests written FIRST (before implementation)
- [x] All new code has corresponding tests
- [ ] All tests pass locally (`pnpm test`)
- [x] Edge cases are covered
- [x] No `any` types used (unless explicitly justified)
- [x] TypeScript strict mode passes (`pnpm tsc --noEmit`)
- [x] ESLint passes (`pnpm lint`)

## Security Checklist

- [x] No Supabase calls from client-side code
- [x] No sensitive data exposed in client bundle
- [x] Input parsing handles encoded values without exceptions
- [x] Rate limiting considered (the public ingestion route already rate-limits requests)

## Testing

Added parser regressions for encoded literal percent signs in display names, trackers, web seeds, and keywords.

### Test Coverage

- Number of new tests: 2
- Test files modified: `src/lib/magnet/magnet.test.ts`, `src/lib/torrent-index/torrent-index.test.ts`

### How to Test

1. Run the two modified parser suites.
2. Parse a magnet containing `dn=100%25ZZ`.
3. Confirm the decoded name is `100%ZZ` without an exception.

Focused validation: 80/80 tests, TypeScript strict mode, ESLint, and `git diff --check`.

The existing local Vitest 4.1.8 installation fails during startup with `ERR_PACKAGE_IMPORT_NOT_DEFINED` even in the untouched source worktree, so the focused suites were run with the already-installed stable Vitest 3 runtime. Official CI remains the authoritative full-suite validation.

## Related Issues

Closes #174
