### PR TITLE
Redact sensitive CoinPayPortal webhook logs

### DIFF
--- a/src/app/api/webhooks/coinpayportal/route.test.ts
+++ b/src/app/api/webhooks/coinpayportal/route.test.ts
@@ -490,6 +490,46 @@ describe('POST /api/webhooks/coinpayportal', () => {
   });
 
   describe('logging', () => {
+    it('does not log webhook signatures, raw bodies, or payment metadata', async () => {
+      const consoleSpies = [
+        vi.spyOn(console, 'log').mockImplementation(() => {}),
+        vi.spyOn(console, 'debug').mockImplementation(() => {}),
+        vi.spyOn(console, 'warn').mockImplementation(() => {}),
+        vi.spyOn(console, 'error').mockImplementation(() => {}),
+      ];
+      const privateMarker = 'private-user-marker';
+      const payload = createValidPayload('payment.confirmed', {
+        metadata: { user_id: privateMarker, plan: 'premium' },
+      });
+      const body = JSON.stringify(payload);
+      const signature = generateSignature(body);
+      mockHandleWebhook.mockResolvedValue({
+        success: true,
+        action: 'subscription_activated',
+        paymentId: 'pay-456',
+      });
+
+      const request = new NextRequest('http://localhost:3000/api/webhooks/coinpayportal', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CoinPay-Signature': signature,
+        },
+        body,
+      });
+
+      await POST(request);
+
+      const serializedLogs = consoleSpies
+        .flatMap((spy) => spy.mock.calls)
+        .flat()
+        .map(String)
+        .join('\n');
+      expect(serializedLogs).not.toContain(signature);
+      expect(serializedLogs).not.toContain(privateMarker);
+      expect(serializedLogs).not.toContain(body);
+    });
+
     it('should log webhook receipt with structured JSON', async () => {
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
       const payload = createValidPayload('payment.confirmed');

--- a/src/app/api/webhooks/coinpayportal/route.ts
+++ b/src/app/api/webhooks/coinpayportal/route.ts
@@ -67,6 +67,14 @@ function log(
   }
 }
 
+function isSensitiveHeader(headerName: string): boolean {
+  const normalizedName = headerName.toLowerCase();
+
+  return ['authorization', 'cookie', 'signature', 'token', 'secret', 'api-key', 'apikey'].some(
+    sensitiveName => normalizedName.includes(sensitiveName)
+  );
+}
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -260,8 +268,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // -------------------------------------------------------------------------
   const headers: Record<string, string> = {};
   request.headers.forEach((value, key) => {
-    // Don't log sensitive headers
-    if (!key.toLowerCase().includes('authorization') && !key.toLowerCase().includes('cookie')) {
+    if (!isSensitiveHeader(key)) {
       headers[key] = value;
     }
   });
@@ -288,7 +295,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     log(requestId, 'DEBUG', 'Raw request body', {
       length: rawBody.length,
-      preview: rawBody.substring(0, 500) + (rawBody.length > 500 ? '...' : ''),
     });
   } catch (readError) {
     const errorMessage = readError instanceof Error ? readError.message : 'Unknown read error';
@@ -313,9 +319,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const isValid = client.verifyWebhookSignature(rawBody, signatureHeader);
 
     if (!isValid) {
-      log(requestId, 'ERROR', 'Invalid webhook signature', {
-        signatureHeader: signatureHeader.substring(0, 50) + '...',
-      });
+      log(requestId, 'ERROR', 'Invalid webhook signature');
       return NextResponse.json({ error: 'Invalid signature', requestId }, { status: 401 });
     }
 
@@ -338,7 +342,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const errorMessage = parseError instanceof Error ? parseError.message : 'Unknown parse error';
     log(requestId, 'ERROR', 'Failed to parse JSON body', {
       error: errorMessage,
-      rawBodyPreview: rawBody?.substring(0, 200),
     });
     return NextResponse.json({ error: 'Invalid JSON body', requestId }, { status: 400 });
   }
@@ -352,7 +355,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!validation.valid) {
     log(requestId, 'ERROR', 'Payload validation failed', {
       error: validation.error,
-      rawBody: rawBody?.substring(0, 1000),
     });
     return NextResponse.json({ error: validation.error, requestId }, { status: 400 });
   }
@@ -378,7 +380,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   if (payload.data.metadata) {
     log(requestId, 'DEBUG', 'Webhook metadata', {
-      metadata: payload.data.metadata,
+      fieldCount: Object.keys(payload.data.metadata).length,
     });
   }
 


### PR DESCRIPTION
## Description

Prevent the CoinPayPortal webhook route from writing authentication material and raw payment data to application logs.

- filter signature-, token-, secret-, cookie-, authorization-, and API-key-style headers;
- retain only the raw body's length instead of a content preview;
- stop logging signature fragments and raw bodies on error paths;
- log only the metadata field count instead of metadata values.

Webhook verification, validation, handler behavior, and API responses remain unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Submission Payout

- [ ] PR: $100 minimum per accepted PR
- [x] Bug fix: $100 minimum per confirmed bug fix
- [ ] QA run: $250 minimum per QA run (files bugs and/or fixes them)
- [ ] Feature/fix: $100 minimum per accepted feature implementation or substantive fix

## TDD Checklist (MANDATORY)

**All items must be checked before merge:**

- [x] Tests written FIRST (before implementation)
- [x] All new code has corresponding tests
- [ ] All tests pass locally (`pnpm test`)
- [x] Edge cases are covered
- [x] No `any` types used (unless explicitly justified)
- [x] TypeScript strict mode passes (`pnpm tsc --noEmit`)
- [x] ESLint passes (`pnpm lint`)

## Security Checklist

- [x] No Supabase calls from client-side code
- [x] No sensitive data exposed in client bundle
- [x] Sensitive webhook headers and payload values are excluded from logs
- [x] Rate limiting considered (not changed by this logging-only fix)

## Testing

Added a regression that captures every console level for a valid signed webhook and verifies that the serialized logs do not contain the signature, raw body, or private metadata marker.

### Test Coverage

- Number of new tests: 1
- Test file modified: `src/app/api/webhooks/coinpayportal/route.test.ts`

### How to Test

1. Run `vitest run src/app/api/webhooks/coinpayportal/route.test.ts`.
2. Send a signed webhook containing a unique metadata value.
3. Confirm logs include body length and metadata field count, but not the signature, raw body, or metadata value.

Validation:
- CoinPayPortal route: 25/25 passing.
- TypeScript strict mode: passing.
- ESLint on both changed files: passing.
- `git diff --check`: passing.
- Full suite: 2,563 passing and 7 skipped; five unrelated Windows-only failures remain because `src/lib/ffmpeg-manager.test.ts` spawns Unix `sleep`/`echo` commands and `src/lib/config/temp-dir.test.ts` expects Unix paths.

## Related Issues

Closes #176
