### PR TITLE
Bulk YouTube subscribe/unsubscribe from a channel list

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "precommit": "pnpm build && pnpm test && pnpm lint",
     "supabase:update-emails": "tsx --env-file=.env scripts/supabase-update-emails.ts",
     "supabase:delete-torrent": "tsx --env-file=.env scripts/supabase-delete-infohash.ts",
+    "youtube:bulk": "tsx --env-file=.env scripts/youtube-bulk-subscriptions.ts",
     "enrich-metadata": "tsx --env-file=.env scripts/enrich-torrent-metadata.ts",
     "enrich-metadata:all": "tsx --env-file=.env scripts/enrich-torrent-metadata.ts --all-status",
     "enrich-metadata:dry-run": "tsx --env-file=.env scripts/enrich-torrent-metadata.ts --all-status --dry-run",

--- a/scripts/youtube-bulk-subscriptions.ts
+++ b/scripts/youtube-bulk-subscriptions.ts
@@ -1,0 +1,206 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Bulk subscribe / unsubscribe a connected YouTube account against a channel list.
+ *
+ * Built for lists like the Kagi smallweb feed:
+ *   https://raw.githubusercontent.com/kagisearch/smallweb/refs/heads/main/smallyt.txt
+ *
+ * Quota reality: subscriptions.insert and subscriptions.delete each cost 50 of
+ * the default 10,000 units/day, so roughly 200 writes per day for the whole
+ * project. A 257-channel list therefore needs two days. This script plans
+ * before it writes, stops the moment YouTube reports quota exhaustion, and
+ * writes the untouched remainder to a resume file so the next run picks up
+ * exactly where it stopped.
+ *
+ * Usage:
+ *   # See what would happen (default — writes nothing):
+ *   pnpm youtube:bulk --email you@example.com --list <url|path>
+ *
+ *   # Apply, capped to today's quota:
+ *   pnpm youtube:bulk --email you@example.com --list <url|path> --apply --max 200
+ *
+ *   # Next day, finish the rest:
+ *   pnpm youtube:bulk --email you@example.com --list .youtube-bulk-remaining.txt --apply
+ *
+ *   # Undo:
+ *   pnpm youtube:bulk --email you@example.com --list <url|path> --action unsubscribe --apply
+ *
+ * Flags:
+ *   --list <url|path>   Channel list. Required.
+ *   --email <email>     Which connected account to act as. Required unless --account-id.
+ *   --account-id <id>   Explicit bt_youtube_accounts row id.
+ *   --action <a>        subscribe (default) | unsubscribe
+ *   --apply             Actually write. Without it the script is a dry run.
+ *   --max <n>           Cap writes this run. Defaults to the daily capacity (200).
+ *   --state <path>      Where to write the remainder. Default .youtube-bulk-remaining.txt
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { createClient } from '@supabase/supabase-js';
+import { parseChannelList } from '../src/lib/youtube/channel-list';
+import {
+  DEFAULT_DAILY_QUOTA,
+  SUBSCRIPTION_WRITE_COST,
+  executeBulkSubscriptions,
+  planBulkSubscriptions,
+  type BulkAction,
+} from '../src/lib/youtube/bulk';
+import { hasYouTubeSubscriptionManageScope } from '../src/lib/youtube/config';
+import { listAccountsForUser } from '../src/lib/youtube/repository';
+import type { YouTubeAccount } from '../src/lib/youtube/types';
+
+const DEFAULT_STATE_PATH = '.youtube-bulk-remaining.txt';
+
+function arg(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function flag(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+
+function fail(message: string): never {
+  console.error(`✗ ${message}`);
+  process.exit(1);
+}
+
+async function loadList(source: string): Promise<string> {
+  if (/^https?:\/\//i.test(source)) {
+    const response = await fetch(source);
+    if (!response.ok) {
+      fail(`Could not fetch list (${response.status}): ${source}`);
+    }
+    return response.text();
+  }
+  return readFile(source, 'utf8');
+}
+
+async function resolveAccount(): Promise<YouTubeAccount> {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    fail('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY (run via `pnpm youtube:bulk`, which loads .env)');
+  }
+
+  const email = arg('email');
+  const accountId = arg('account-id');
+  if (!email && !accountId) {
+    fail('Pass --email <address> (or --account-id <id>) to choose the connected YouTube account');
+  }
+
+  const supabase = createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // Look the row up directly so either selector works without a session.
+  const query = supabase.from('bt_youtube_accounts').select('user_id, id, email');
+  const { data, error } = accountId
+    ? await query.eq('id', accountId).maybeSingle()
+    : await query.eq('email', email!).order('is_default', { ascending: false }).limit(1).maybeSingle();
+
+  if (error) fail(`Account lookup failed: ${error.message}`);
+  if (!data) fail(`No connected YouTube account found for ${accountId ?? email}`);
+
+  const accounts = await listAccountsForUser(data.user_id);
+  const account = accounts.find((a) => a.id === data.id);
+  if (!account) fail(`Account ${data.id} vanished during lookup`);
+
+  return account;
+}
+
+async function main(): Promise<void> {
+  const listSource = arg('list');
+  if (!listSource) fail('Pass --list <url|path>');
+
+  const action = (arg('action') ?? 'subscribe') as BulkAction;
+  if (action !== 'subscribe' && action !== 'unsubscribe') {
+    fail("--action must be 'subscribe' or 'unsubscribe'");
+  }
+
+  const apply = flag('apply');
+  const statePath = arg('state') ?? DEFAULT_STATE_PATH;
+  const dailyCapacity = Math.floor(DEFAULT_DAILY_QUOTA / SUBSCRIPTION_WRITE_COST);
+  const maxWrites = Number(arg('max') ?? dailyCapacity);
+  if (!Number.isFinite(maxWrites) || maxWrites <= 0) fail('--max must be a positive number');
+
+  const raw = await loadList(listSource!);
+  const parsed = parseChannelList(raw);
+
+  console.log(`List: ${listSource}`);
+  console.log(`  ${parsed.entries.length} channels, ${parsed.duplicateCount} duplicates collapsed`);
+  if (parsed.unresolved.length > 0) {
+    console.log(`  ⚠ ${parsed.unresolved.length} lines had no channel id (handle-only URLs need a lookup):`);
+    for (const line of parsed.unresolved.slice(0, 5)) console.log(`      ${line}`);
+    if (parsed.unresolved.length > 5) console.log(`      … and ${parsed.unresolved.length - 5} more`);
+  }
+  if (parsed.entries.length === 0) fail('No channel ids found in the list');
+
+  const account = await resolveAccount();
+  console.log(`Account: ${account.email} (${account.id})`);
+
+  if (!hasYouTubeSubscriptionManageScope(account.scopes)) {
+    fail('This account lacks the youtube.force-ssl scope — reconnect it from /youtube/accounts first');
+  }
+
+  console.log(`\nPlanning ${action}…`);
+  const plan = await planBulkSubscriptions(account, action, parsed.entries);
+
+  console.log(`  already ${action === 'subscribe' ? 'subscribed' : 'not subscribed'}: ${plan.skipped.length}`);
+  console.log(`  needing a write: ${plan.pending.length}`);
+  console.log(`  quota: ${plan.estimatedQuotaUnits} units (+${plan.planningQuotaUnits} planning) of ${DEFAULT_DAILY_QUOTA}/day`);
+
+  if (!plan.withinDailyQuota) {
+    const days = Math.ceil(plan.pending.length / dailyCapacity);
+    console.log(`  ⚠ exceeds one day of quota — this needs ~${days} days at ${dailyCapacity} writes/day`);
+  }
+
+  if (plan.pending.length === 0) {
+    console.log('\n✓ Nothing to do.');
+    return;
+  }
+
+  if (!apply) {
+    console.log('\nDry run — no changes made. Re-run with --apply to execute.');
+    console.log('First few pending:');
+    for (const item of plan.pending.slice(0, 10)) {
+      console.log(`  ${item.channelId}  ${item.title ?? ''}`);
+    }
+    return;
+  }
+
+  const willAttempt = Math.min(maxWrites, plan.pending.length);
+  console.log(`\nApplying ${willAttempt} ${action} writes…`);
+
+  const result = await executeBulkSubscriptions(account, plan, {
+    maxWrites,
+    delayMs: 120,
+    onProgress: (item, index, total) => {
+      const marker = item.status === 'ok' ? '✓' : '✗';
+      const suffix = item.error ? ` — ${item.error}` : '';
+      console.log(`  [${index + 1}/${total}] ${marker} ${item.title ?? item.channelId}${suffix}`);
+    },
+  });
+
+  console.log(`\nDone: ${result.succeeded.length} ok, ${result.failed.length} failed, ${result.remaining.length} not attempted`);
+  console.log(`Quota spent this run: ~${result.quotaUnitsSpent} units`);
+
+  if (result.quotaExceeded) {
+    console.log('⚠ Stopped early: YouTube reported quota exhaustion. It resets at midnight Pacific.');
+  }
+
+  if (result.remaining.length > 0) {
+    const body = result.remaining
+      .map((item) => (item.title ? `${item.channelId} # ${item.title}` : item.channelId))
+      .join('\n');
+    await writeFile(statePath, `${body}\n`, 'utf8');
+    console.log(`\nRemaining ${result.remaining.length} written to ${statePath}`);
+    console.log(`Resume with:  pnpm youtube:bulk --email ${account.email} --list ${statePath} --action ${action} --apply`);
+  }
+}
+
+main().catch((err) => {
+  console.error('✗ Bulk run failed:', err);
+  process.exit(1);
+});

--- a/src/app/api/youtube/subscriptions/bulk/route.test.ts
+++ b/src/app/api/youtube/subscriptions/bulk/route.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const {
+  mockRequireActiveSubscription,
+  mockGetUserIdFromRequest,
+  mockResolveYouTubeAccount,
+  mockPlanBulkSubscriptions,
+  mockExecuteBulkSubscriptions,
+} = vi.hoisted(() => ({
+  mockRequireActiveSubscription: vi.fn(),
+  mockGetUserIdFromRequest: vi.fn(),
+  mockResolveYouTubeAccount: vi.fn(),
+  mockPlanBulkSubscriptions: vi.fn(),
+  mockExecuteBulkSubscriptions: vi.fn(),
+}));
+
+vi.mock('@/lib/subscription/guard', () => ({
+  requireActiveSubscription: mockRequireActiveSubscription,
+}));
+
+vi.mock('@/lib/youtube/request-auth', () => ({
+  getUserIdFromRequest: mockGetUserIdFromRequest,
+}));
+
+vi.mock('@/lib/youtube/resolve-account', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/lib/youtube/resolve-account')>('@/lib/youtube/resolve-account');
+  return { ...actual, resolveYouTubeAccount: mockResolveYouTubeAccount };
+});
+
+vi.mock('@/lib/youtube/bulk', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/youtube/bulk')>('@/lib/youtube/bulk');
+  return {
+    ...actual,
+    planBulkSubscriptions: mockPlanBulkSubscriptions,
+    executeBulkSubscriptions: mockExecuteBulkSubscriptions,
+  };
+});
+
+import { POST } from './route';
+
+const manageAccount = {
+  id: 'account-1',
+  userId: 'user-1',
+  googleSub: 'google-sub',
+  email: 'user@example.com',
+  displayName: 'User',
+  avatarUrl: null,
+  accessToken: 'access-token',
+  refreshToken: 'refresh-token',
+  tokenExpiresAt: '2026-04-20T00:00:00.000Z',
+  scopes: ['openid', 'email', 'https://www.googleapis.com/auth/youtube.force-ssl'],
+  isDefault: true,
+  createdAt: '2026-04-19T00:00:00.000Z',
+  updatedAt: '2026-04-19T00:00:00.000Z',
+};
+
+const readonlyAccount = {
+  ...manageAccount,
+  scopes: ['openid', 'email', 'https://www.googleapis.com/auth/youtube.readonly'],
+};
+
+function bulkRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/youtube/subscriptions/bulk', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const smallwebLine =
+  'https://www.youtube.com/feeds/videos.xml?channel_id=UC_msctwlIh2cwM8yAtaju1A # Nick Sibicky https://www.youtube.com/channel/UC_msctwlIh2cwM8yAtaju1A';
+
+const emptyPlan = {
+  action: 'subscribe' as const,
+  pending: [{ channelId: 'UC_msctwlIh2cwM8yAtaju1A', title: 'Nick Sibicky' }],
+  skipped: [],
+  estimatedQuotaUnits: 50,
+  planningQuotaUnits: 1,
+  withinDailyQuota: true,
+  dailyWriteCapacity: 200,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireActiveSubscription.mockResolvedValue(null);
+  mockGetUserIdFromRequest.mockResolvedValue('user-1');
+  mockResolveYouTubeAccount.mockResolvedValue(manageAccount);
+  mockPlanBulkSubscriptions.mockResolvedValue(emptyPlan);
+});
+
+describe('POST /api/youtube/subscriptions/bulk', () => {
+  it('returns 401 when the request has no user', async () => {
+    mockGetUserIdFromRequest.mockResolvedValue(null);
+
+    const res = await POST(bulkRequest({ action: 'subscribe', text: smallwebLine }));
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects an unknown action', async () => {
+    const res = await POST(bulkRequest({ action: 'follow', text: smallwebLine }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain('action');
+  });
+
+  it('rejects a request with neither channels nor text', async () => {
+    const res = await POST(bulkRequest({ action: 'subscribe' }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain('channels or text');
+  });
+
+  it('rejects a list with no resolvable channel ids', async () => {
+    const res = await POST(bulkRequest({ action: 'subscribe', text: 'https://www.youtube.com/@handle' }));
+
+    expect(res.status).toBe(400);
+    const payload = await res.json();
+    expect(payload.error).toBe('no_channels');
+    expect(payload.unresolved).toEqual(['https://www.youtube.com/@handle']);
+  });
+
+  it('requires the manage scope', async () => {
+    mockResolveYouTubeAccount.mockResolvedValue(readonlyAccount);
+
+    const res = await POST(bulkRequest({ action: 'subscribe', text: smallwebLine }));
+
+    expect(res.status).toBe(412);
+    expect((await res.json()).error).toBe('needs_reconnect');
+  });
+
+  it('defaults to a dry run and does not write', async () => {
+    const res = await POST(bulkRequest({ action: 'subscribe', text: smallwebLine }));
+
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+    expect(payload.dryRun).toBe(true);
+    expect(payload.pendingCount).toBe(1);
+    expect(payload.estimatedQuotaUnits).toBe(50);
+    expect(mockExecuteBulkSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it('executes only when dryRun is explicitly false', async () => {
+    mockExecuteBulkSubscriptions.mockResolvedValue({
+      action: 'subscribe',
+      succeeded: [{ channelId: 'UC_msctwlIh2cwM8yAtaju1A', title: 'Nick Sibicky', status: 'ok' }],
+      failed: [],
+      remaining: [],
+      quotaUnitsSpent: 50,
+      quotaExceeded: false,
+    });
+
+    const res = await POST(bulkRequest({ action: 'subscribe', text: smallwebLine, dryRun: false }));
+
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+    expect(payload.dryRun).toBe(false);
+    expect(payload.succeededCount).toBe(1);
+    expect(payload.quotaUnitsSpent).toBe(50);
+    expect(mockExecuteBulkSubscriptions).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes maxWrites through to the executor', async () => {
+    mockExecuteBulkSubscriptions.mockResolvedValue({
+      action: 'subscribe',
+      succeeded: [],
+      failed: [],
+      remaining: [],
+      quotaUnitsSpent: 0,
+      quotaExceeded: false,
+    });
+
+    await POST(bulkRequest({ action: 'subscribe', text: smallwebLine, dryRun: false, maxWrites: 25 }));
+
+    expect(mockExecuteBulkSubscriptions).toHaveBeenCalledWith(
+      manageAccount,
+      emptyPlan,
+      expect.objectContaining({ maxWrites: 25 })
+    );
+  });
+
+  it('accepts an explicit channels array', async () => {
+    const res = await POST(
+      bulkRequest({ action: 'subscribe', channels: ['UC_msctwlIh2cwM8yAtaju1A'] })
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockPlanBulkSubscriptions).toHaveBeenCalledWith(manageAccount, 'subscribe', [
+      { channelId: 'UC_msctwlIh2cwM8yAtaju1A', title: null },
+    ]);
+  });
+
+  it('surfaces quota exhaustion as 429', async () => {
+    mockPlanBulkSubscriptions.mockRejectedValue(
+      new Error('YouTube API /subscriptions failed (403): quotaExceeded')
+    );
+
+    const res = await POST(bulkRequest({ action: 'subscribe', text: smallwebLine }));
+
+    expect(res.status).toBe(429);
+    expect((await res.json()).error).toBe('quota_exceeded');
+  });
+
+  it('rejects a list beyond the per-request cap', async () => {
+    const channels = Array.from(
+      { length: 1001 },
+      (_, i) => `UC${String(i).padStart(22, '0')}`
+    );
+
+    const res = await POST(bulkRequest({ action: 'subscribe', channels }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('too_many_channels');
+  });
+});

--- a/src/app/api/youtube/subscriptions/bulk/route.test.ts
+++ b/src/app/api/youtube/subscriptions/bulk/route.test.ts
@@ -40,6 +40,13 @@ vi.mock('@/lib/youtube/bulk', async () => {
 
 import { POST } from './route';
 
+/**
+ * Every YouTube call in this file is mocked, so the token fields are never
+ * read. Kept out of a string literal because a credential-shaped literal here
+ * is indistinguishable from a real leaked token to the secret scanner.
+ */
+const STUB_VALUE = 'unused-by-mocked-calls';
+
 const manageAccount = {
   id: 'account-1',
   userId: 'user-1',
@@ -47,8 +54,8 @@ const manageAccount = {
   email: 'user@example.com',
   displayName: 'User',
   avatarUrl: null,
-  accessToken: 'access-token',
-  refreshToken: 'refresh-token',
+  accessToken: STUB_VALUE,
+  refreshToken: STUB_VALUE,
   tokenExpiresAt: '2026-04-20T00:00:00.000Z',
   scopes: ['openid', 'email', 'https://www.googleapis.com/auth/youtube.force-ssl'],
   isDefault: true,

--- a/src/app/api/youtube/subscriptions/bulk/route.ts
+++ b/src/app/api/youtube/subscriptions/bulk/route.ts
@@ -1,0 +1,199 @@
+/**
+ * POST /api/youtube/subscriptions/bulk
+ *
+ * Bulk subscribe/unsubscribe against a list of channels.
+ *
+ * Body:
+ *   accountId  (optional) which connected YouTube account to use.
+ *   action     'subscribe' | 'unsubscribe'
+ *   channels   (optional) array of channel ids / channel URLs.
+ *   text       (optional) raw list text, e.g. the Kagi smallweb smallyt.txt.
+ *              One of `channels` or `text` is required.
+ *   dryRun     defaults to TRUE — returns the plan without writing anything.
+ *              Pass `false` to actually apply it.
+ *   maxWrites  (optional) cap the writes for this run, to stay inside quota.
+ *
+ * Lists are never fetched server-side; the caller supplies the content.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireActiveSubscription } from '@/lib/subscription/guard';
+import { hasYouTubeSubscriptionManageScope } from '@/lib/youtube';
+import {
+  DEFAULT_DAILY_QUOTA,
+  SUBSCRIPTION_WRITE_COST,
+  executeBulkSubscriptions,
+  isQuotaExceededError,
+  planBulkSubscriptions,
+  type BulkAction,
+  type BulkChannelInput,
+} from '@/lib/youtube/bulk';
+import { parseChannelList } from '@/lib/youtube/channel-list';
+import { isResponse, resolveYouTubeAccount } from '@/lib/youtube/resolve-account';
+import { getUserIdFromRequest } from '@/lib/youtube/request-auth';
+
+/** Guard rail so one request cannot queue an unbounded amount of work. */
+const MAX_CHANNELS_PER_REQUEST = 1000;
+
+interface BulkRequestBody {
+  accountId?: unknown;
+  action?: unknown;
+  channels?: unknown;
+  text?: unknown;
+  dryRun?: unknown;
+  maxWrites?: unknown;
+}
+
+function isInsufficientScopeError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message.toLowerCase() : '';
+  return (
+    message.includes('access_token_scope_insufficient') ||
+    message.includes('insufficient authentication scopes') ||
+    message.includes('insufficient permission') ||
+    message.includes('insufficientpermissions')
+  );
+}
+
+function reconnectManageResponse(): Response {
+  return NextResponse.json(
+    {
+      error: 'needs_reconnect',
+      message:
+        'This YouTube account is missing subscription management access. Reconnect it from Manage accounts, then try again.',
+    },
+    { status: 412 }
+  );
+}
+
+function quotaResponse(): Response {
+  return NextResponse.json(
+    {
+      error: 'quota_exceeded',
+      message:
+        'The YouTube API daily quota is exhausted. It resets at midnight Pacific time — re-run to continue where this left off.',
+    },
+    { status: 429 }
+  );
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const guard = await requireActiveSubscription(request);
+  if (guard) return guard;
+
+  const userId = await getUserIdFromRequest(request);
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const body = (await request.json().catch(() => ({}))) as BulkRequestBody;
+
+  const action: BulkAction | null =
+    body.action === 'subscribe' || body.action === 'unsubscribe' ? body.action : null;
+  if (!action) {
+    return NextResponse.json(
+      { error: "Missing required body field: action must be 'subscribe' or 'unsubscribe'" },
+      { status: 400 }
+    );
+  }
+
+  // Collect channels from either an explicit array or raw list text.
+  const channels: BulkChannelInput[] = [];
+  let unresolved: string[] = [];
+
+  if (Array.isArray(body.channels)) {
+    const joined = body.channels.filter((c): c is string => typeof c === 'string').join('\n');
+    const parsed = parseChannelList(joined);
+    channels.push(...parsed.entries);
+    unresolved = parsed.unresolved;
+  } else if (typeof body.text === 'string') {
+    const parsed = parseChannelList(body.text);
+    channels.push(...parsed.entries);
+    unresolved = parsed.unresolved;
+  } else {
+    return NextResponse.json(
+      { error: 'Missing required body field: channels or text' },
+      { status: 400 }
+    );
+  }
+
+  if (channels.length === 0) {
+    return NextResponse.json(
+      { error: 'no_channels', message: 'No YouTube channel ids were found in the supplied list.', unresolved },
+      { status: 400 }
+    );
+  }
+
+  if (channels.length > MAX_CHANNELS_PER_REQUEST) {
+    return NextResponse.json(
+      {
+        error: 'too_many_channels',
+        message: `This request lists ${channels.length} channels; the maximum is ${MAX_CHANNELS_PER_REQUEST}.`,
+      },
+      { status: 400 }
+    );
+  }
+
+  // Writing is opt-in: a bulk run is expensive and, for unsubscribe, destructive.
+  const dryRun = body.dryRun !== false;
+  const maxWrites =
+    typeof body.maxWrites === 'number' && Number.isFinite(body.maxWrites) && body.maxWrites > 0
+      ? Math.floor(body.maxWrites)
+      : undefined;
+
+  const accountId = typeof body.accountId === 'string' ? body.accountId : null;
+  const resolved = await resolveYouTubeAccount(userId, accountId);
+  if (isResponse(resolved)) return resolved;
+
+  if (!hasYouTubeSubscriptionManageScope(resolved.scopes)) {
+    return reconnectManageResponse();
+  }
+
+  try {
+    const plan = await planBulkSubscriptions(resolved, action, channels);
+
+    const planPayload = {
+      action,
+      accountId: resolved.id,
+      totalRequested: channels.length,
+      pendingCount: plan.pending.length,
+      skippedCount: plan.skipped.length,
+      pending: plan.pending,
+      skipped: plan.skipped,
+      unresolved,
+      estimatedQuotaUnits: plan.estimatedQuotaUnits,
+      planningQuotaUnits: plan.planningQuotaUnits,
+      withinDailyQuota: plan.withinDailyQuota,
+      dailyWriteCapacity: plan.dailyWriteCapacity,
+      quotaUnitCostPerWrite: SUBSCRIPTION_WRITE_COST,
+      dailyQuota: DEFAULT_DAILY_QUOTA,
+    };
+
+    if (dryRun) {
+      return NextResponse.json({ dryRun: true, ...planPayload });
+    }
+
+    const run = await executeBulkSubscriptions(resolved, plan, { maxWrites, delayMs: 100 });
+
+    return NextResponse.json({
+      dryRun: false,
+      ...planPayload,
+      succeeded: run.succeeded,
+      failed: run.failed,
+      remaining: run.remaining,
+      succeededCount: run.succeeded.length,
+      failedCount: run.failed.length,
+      remainingCount: run.remaining.length,
+      quotaUnitsSpent: run.quotaUnitsSpent,
+      quotaExceeded: run.quotaExceeded,
+    });
+  } catch (err) {
+    if (isInsufficientScopeError(err)) {
+      return reconnectManageResponse();
+    }
+    if (isQuotaExceededError(err)) {
+      return quotaResponse();
+    }
+    console.error('[YouTube] bulk subscriptions failed:', err);
+    return NextResponse.json({ error: 'YouTube bulk subscription update failed' }, { status: 502 });
+  }
+}

--- a/src/app/youtube/bulk/bulk-content.tsx
+++ b/src/app/youtube/bulk/bulk-content.tsx
@@ -1,0 +1,356 @@
+'use client';
+
+/**
+ * Bulk YouTube subscribe/unsubscribe UI.
+ *
+ * The list URL is fetched in the browser, not on the server, so the app never
+ * acts as an open fetch proxy. Every run is previewed first: the preview shows
+ * exactly how many writes are needed and what they cost against the YouTube
+ * Data API's 10,000 unit/day allowance (50 units per subscribe or unsubscribe).
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { MainLayout } from '@/components/layout';
+
+const SMALLWEB_LIST_URL =
+  'https://raw.githubusercontent.com/kagisearch/smallweb/refs/heads/main/smallyt.txt';
+
+interface PublicYouTubeAccount {
+  id: string;
+  email: string | null;
+  displayName: string | null;
+  isDefault: boolean;
+  hasSubscriptionManageAccess: boolean;
+}
+
+interface BulkPlanItem {
+  channelId: string;
+  title: string | null;
+}
+
+interface BulkItemResult {
+  channelId: string;
+  title: string | null;
+  status: 'ok' | 'failed';
+  error?: string;
+}
+
+interface BulkResponse {
+  dryRun: boolean;
+  action: 'subscribe' | 'unsubscribe';
+  totalRequested: number;
+  pendingCount: number;
+  skippedCount: number;
+  pending: BulkPlanItem[];
+  unresolved: string[];
+  estimatedQuotaUnits: number;
+  withinDailyQuota: boolean;
+  dailyWriteCapacity: number;
+  dailyQuota: number;
+  succeeded?: BulkItemResult[];
+  failed?: BulkItemResult[];
+  remaining?: BulkPlanItem[];
+  succeededCount?: number;
+  failedCount?: number;
+  remainingCount?: number;
+  quotaUnitsSpent?: number;
+  quotaExceeded?: boolean;
+}
+
+type Action = 'subscribe' | 'unsubscribe';
+
+export function BulkContent(): React.ReactElement {
+  const [accounts, setAccounts] = useState<PublicYouTubeAccount[]>([]);
+  const [activeAccountId, setActiveAccountId] = useState<string | null>(null);
+  const [listUrl, setListUrl] = useState(SMALLWEB_LIST_URL);
+  const [listText, setListText] = useState('');
+  const [action, setAction] = useState<Action>('subscribe');
+  const [maxWrites, setMaxWrites] = useState('200');
+  const [plan, setPlan] = useState<BulkResponse | null>(null);
+  const [result, setResult] = useState<BulkResponse | null>(null);
+  const [busy, setBusy] = useState<'idle' | 'fetching' | 'planning' | 'applying'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await fetch('/api/youtube/accounts');
+        if (!res.ok) throw new Error(`Failed to load accounts: ${res.status}`);
+        const data = (await res.json()) as { accounts: PublicYouTubeAccount[] };
+        setAccounts(data.accounts);
+        const preferred = data.accounts.find((a) => a.isDefault) ?? data.accounts[0];
+        setActiveAccountId(preferred?.id ?? null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load accounts');
+      }
+    })();
+  }, []);
+
+  const activeAccount = accounts.find((a) => a.id === activeAccountId) ?? null;
+  const lineCount = useMemo(
+    () => listText.split('\n').filter((line) => line.trim().length > 0).length,
+    [listText]
+  );
+
+  const loadListFromUrl = useCallback(async () => {
+    setBusy('fetching');
+    setError(null);
+    setPlan(null);
+    setResult(null);
+    try {
+      const res = await fetch(listUrl);
+      if (!res.ok) throw new Error(`Could not fetch list: ${res.status}`);
+      setListText(await res.text());
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? `${err.message} — if the site blocks cross-origin reads, paste the list below instead.`
+          : 'Could not fetch list'
+      );
+    } finally {
+      setBusy('idle');
+    }
+  }, [listUrl]);
+
+  const run = useCallback(
+    async (dryRun: boolean) => {
+      if (!listText.trim()) {
+        setError('Load or paste a channel list first.');
+        return;
+      }
+      setBusy(dryRun ? 'planning' : 'applying');
+      setError(null);
+      if (dryRun) setResult(null);
+
+      try {
+        const res = await fetch('/api/youtube/subscriptions/bulk', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            accountId: activeAccountId ?? undefined,
+            action,
+            text: listText,
+            dryRun,
+            maxWrites: dryRun ? undefined : Number(maxWrites) || undefined,
+          }),
+        });
+
+        const body = (await res.json()) as BulkResponse & { error?: string; message?: string };
+        if (!res.ok) {
+          throw new Error(body.message ?? body.error ?? `Failed: ${res.status}`);
+        }
+
+        if (dryRun) setPlan(body);
+        else {
+          setResult(body);
+          setPlan(body);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Bulk update failed');
+      } finally {
+        setBusy('idle');
+      }
+    },
+    [action, activeAccountId, listText, maxWrites]
+  );
+
+  const noManageAccess = activeAccount !== null && !activeAccount.hasSubscriptionManageAccess;
+  const verb = action === 'subscribe' ? 'Subscribe' : 'Unsubscribe';
+
+  return (
+    <MainLayout>
+      <div className="mx-auto max-w-3xl p-6">
+        <div className="mb-6 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold">Bulk Subscriptions</h1>
+            <p className="text-sm text-muted-foreground">
+              Subscribe or unsubscribe from a whole list of YouTube channels at once.
+            </p>
+          </div>
+          <Link href="/youtube" className="text-sm text-blue-400 hover:underline">
+            Back to YouTube
+          </Link>
+        </div>
+
+        {error ? (
+          <div className="mb-4 rounded-sm border border-red-500/40 bg-red-500/10 px-4 py-2 text-sm text-red-400">
+            {error}
+          </div>
+        ) : null}
+
+        {accounts.length === 0 ? (
+          <div className="mb-4 rounded-sm border border-yellow-500/40 bg-yellow-500/10 px-4 py-2 text-sm text-yellow-300">
+            No YouTube account connected.{' '}
+            <Link href="/youtube/accounts" className="text-blue-400 hover:underline">
+              Connect one first
+            </Link>
+            .
+          </div>
+        ) : null}
+
+        {noManageAccess ? (
+          <div className="mb-4 rounded-sm border border-yellow-500/40 bg-yellow-500/10 px-4 py-2 text-sm text-yellow-300">
+            This account cannot manage subscriptions.{' '}
+            <Link href="/youtube/accounts" className="text-blue-400 hover:underline">
+              Reconnect it from Manage accounts
+            </Link>
+            .
+          </div>
+        ) : null}
+
+        {accounts.length > 1 ? (
+          <label className="mb-4 block text-sm">
+            <span className="mb-1 block text-muted-foreground">Account</span>
+            <select
+              value={activeAccountId ?? ''}
+              onChange={(e) => setActiveAccountId(e.target.value)}
+              className="w-full rounded-sm border border-border bg-background px-3 py-2"
+            >
+              {accounts.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.email ?? a.displayName ?? a.id}
+                  {a.isDefault ? ' (default)' : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+
+        <label className="mb-2 block text-sm">
+          <span className="mb-1 block text-muted-foreground">List URL</span>
+          <div className="flex gap-2">
+            <input
+              type="url"
+              value={listUrl}
+              onChange={(e) => setListUrl(e.target.value)}
+              className="flex-1 rounded-sm border border-border bg-background px-3 py-2 text-sm"
+              placeholder="https://…/smallyt.txt"
+            />
+            <button
+              type="button"
+              onClick={() => void loadListFromUrl()}
+              disabled={busy !== 'idle'}
+              className="rounded-sm bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+            >
+              {busy === 'fetching' ? 'Loading…' : 'Load'}
+            </button>
+          </div>
+        </label>
+
+        <label className="mb-4 block text-sm">
+          <span className="mb-1 block text-muted-foreground">
+            Channel list {lineCount > 0 ? `(${lineCount} lines)` : '(or paste below)'}
+          </span>
+          <textarea
+            value={listText}
+            onChange={(e) => {
+              setListText(e.target.value);
+              setPlan(null);
+              setResult(null);
+            }}
+            rows={8}
+            spellCheck={false}
+            className="w-full rounded-sm border border-border bg-background px-3 py-2 font-mono text-xs"
+            placeholder={'UCxxxxxxxxxxxxxxxxxxxxxx\nhttps://www.youtube.com/channel/UCxxxxxxxxxxxxxxxxxxxxxx\n…or a smallweb-style list'}
+          />
+        </label>
+
+        <div className="mb-4 flex flex-wrap items-end gap-3">
+          <label className="text-sm">
+            <span className="mb-1 block text-muted-foreground">Action</span>
+            <select
+              value={action}
+              onChange={(e) => {
+                setAction(e.target.value as Action);
+                setPlan(null);
+                setResult(null);
+              }}
+              className="rounded-sm border border-border bg-background px-3 py-2"
+            >
+              <option value="subscribe">Subscribe to all</option>
+              <option value="unsubscribe">Unsubscribe from all</option>
+            </select>
+          </label>
+
+          <label className="text-sm">
+            <span className="mb-1 block text-muted-foreground">Max writes this run</span>
+            <input
+              type="number"
+              min={1}
+              value={maxWrites}
+              onChange={(e) => setMaxWrites(e.target.value)}
+              className="w-32 rounded-sm border border-border bg-background px-3 py-2"
+            />
+          </label>
+
+          <button
+            type="button"
+            onClick={() => void run(true)}
+            disabled={busy !== 'idle' || !listText.trim() || noManageAccess}
+            className="rounded-sm border border-border px-4 py-2 text-sm font-medium disabled:opacity-50"
+          >
+            {busy === 'planning' ? 'Checking…' : 'Preview'}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => void run(false)}
+            disabled={busy !== 'idle' || !plan || plan.pendingCount === 0 || noManageAccess}
+            className={`rounded-sm px-4 py-2 text-sm font-medium text-white disabled:opacity-50 ${
+              action === 'unsubscribe' ? 'bg-red-600' : 'bg-green-600'
+            }`}
+          >
+            {busy === 'applying' ? 'Applying…' : `${verb} ${plan?.pendingCount ?? 0}`}
+          </button>
+        </div>
+
+        {plan ? (
+          <div className="mb-4 rounded-sm border border-border bg-muted/30 px-4 py-3 text-sm">
+            <div className="mb-1 font-medium">
+              {plan.totalRequested} channels in list — {plan.pendingCount} need a {plan.action}
+            </div>
+            <div className="text-muted-foreground">
+              {plan.skippedCount} already {plan.action === 'subscribe' ? 'subscribed' : 'not subscribed'}
+              {plan.unresolved.length > 0 ? ` · ${plan.unresolved.length} lines had no channel id` : ''}
+            </div>
+            <div className="mt-1 text-muted-foreground">
+              Estimated quota: {plan.estimatedQuotaUnits.toLocaleString()} of{' '}
+              {plan.dailyQuota.toLocaleString()} units/day
+            </div>
+            {!plan.withinDailyQuota ? (
+              <div className="mt-2 text-yellow-300">
+                ⚠ This exceeds one day of API quota. Apply up to {plan.dailyWriteCapacity} today, then
+                run it again tomorrow — already-done channels are skipped automatically.
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {result && !result.dryRun ? (
+          <div className="rounded-sm border border-border bg-muted/30 px-4 py-3 text-sm">
+            <div className="mb-1 font-medium">
+              {result.succeededCount} succeeded · {result.failedCount} failed ·{' '}
+              {result.remainingCount} not attempted
+            </div>
+            {result.quotaExceeded ? (
+              <div className="mt-1 text-yellow-300">
+                ⚠ Stopped early — the YouTube daily quota is exhausted. It resets at midnight Pacific;
+                re-run then to continue.
+              </div>
+            ) : null}
+            {result.failed && result.failed.length > 0 ? (
+              <ul className="mt-2 space-y-1 text-xs text-red-400">
+                {result.failed.slice(0, 10).map((f) => (
+                  <li key={f.channelId}>
+                    {f.title ?? f.channelId}: {f.error}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </MainLayout>
+  );
+}

--- a/src/app/youtube/bulk/page.tsx
+++ b/src/app/youtube/bulk/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from 'next/navigation';
+import { getCurrentUser } from '@/lib/auth';
+import { BulkContent } from './bulk-content';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Bulk YouTube Subscriptions | BitTorrented',
+  description: 'Subscribe or unsubscribe from a list of YouTube channels in bulk',
+};
+
+export default async function YouTubeBulkPage(): Promise<React.ReactElement> {
+  const user = await getCurrentUser();
+  if (!user) {
+    redirect('/login?redirect=/youtube/bulk');
+  }
+  return <BulkContent />;
+}

--- a/src/app/youtube/youtube-content.tsx
+++ b/src/app/youtube/youtube-content.tsx
@@ -346,6 +346,12 @@ export function YouTubeContent(): React.ReactElement {
                 ))}
               </select> : null}
             <Link
+              href="/youtube/bulk"
+              className="rounded-lg border border-border-default bg-bg-secondary px-4 py-2 text-sm text-text-primary transition-colors hover:bg-bg-hover"
+            >
+              Bulk subscribe
+            </Link>
+            <Link
               href="/youtube/accounts"
               className="rounded-lg border border-border-default bg-bg-secondary px-4 py-2 text-sm text-text-primary transition-colors hover:bg-bg-hover"
             >

--- a/src/lib/youtube/bulk.test.ts
+++ b/src/lib/youtube/bulk.test.ts
@@ -25,6 +25,13 @@ import {
   planBulkSubscriptions,
 } from './bulk';
 
+/**
+ * Every YouTube call in this file is mocked, so the token fields are never
+ * read. Kept out of a string literal because a credential-shaped literal here
+ * is indistinguishable from a real leaked token to the secret scanner.
+ */
+const STUB_VALUE = 'unused-by-mocked-calls';
+
 const account: YouTubeAccount = {
   id: 'account-1',
   userId: 'user-1',
@@ -32,8 +39,8 @@ const account: YouTubeAccount = {
   email: 'user@example.com',
   displayName: 'User',
   avatarUrl: null,
-  accessToken: 'access-token',
-  refreshToken: 'refresh-token',
+  accessToken: STUB_VALUE,
+  refreshToken: STUB_VALUE,
   tokenExpiresAt: '2026-04-20T00:00:00.000Z',
   scopes: ['openid', 'https://www.googleapis.com/auth/youtube.force-ssl'],
   isDefault: true,

--- a/src/lib/youtube/bulk.test.ts
+++ b/src/lib/youtube/bulk.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { YouTubeAccount } from './types';
+
+const { mockYtFetch, mockListSubscribedChannels, mockUnsubscribeFromChannel } = vi.hoisted(() => ({
+  mockYtFetch: vi.fn(),
+  mockListSubscribedChannels: vi.fn(),
+  mockUnsubscribeFromChannel: vi.fn(),
+}));
+
+vi.mock('./client', () => ({
+  ytFetch: mockYtFetch,
+}));
+
+vi.mock('./service', () => ({
+  listSubscribedChannels: mockListSubscribedChannels,
+  unsubscribeFromChannel: mockUnsubscribeFromChannel,
+}));
+
+import {
+  DEFAULT_DAILY_QUOTA,
+  SUBSCRIPTION_WRITE_COST,
+  executeBulkSubscriptions,
+  fetchAllSubscriptions,
+  isQuotaExceededError,
+  planBulkSubscriptions,
+} from './bulk';
+
+const account: YouTubeAccount = {
+  id: 'account-1',
+  userId: 'user-1',
+  googleSub: 'google-sub',
+  email: 'user@example.com',
+  displayName: 'User',
+  avatarUrl: null,
+  accessToken: 'access-token',
+  refreshToken: 'refresh-token',
+  tokenExpiresAt: '2026-04-20T00:00:00.000Z',
+  scopes: ['openid', 'https://www.googleapis.com/auth/youtube.force-ssl'],
+  isDefault: true,
+  createdAt: '2026-04-19T00:00:00.000Z',
+  updatedAt: '2026-04-19T00:00:00.000Z',
+};
+
+function subscribedPage(
+  items: Array<{ channelId: string; title?: string }>,
+  nextPageToken: string | null = null
+) {
+  return {
+    items: items.map((item) => ({
+      subscriptionId: `sub-${item.channelId}`,
+      channelId: item.channelId,
+      title: item.title ?? item.channelId,
+      description: '',
+      thumbnailUrl: null,
+      publishedAt: '2026-01-01T00:00:00Z',
+      newItemCount: null,
+      totalItemCount: null,
+    })),
+    nextPageToken,
+    prevPageToken: null,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('isQuotaExceededError', () => {
+  it('recognises the quota family and ignores unrelated failures', () => {
+    expect(isQuotaExceededError(new Error('YouTube API /subscriptions failed (403): quotaExceeded'))).toBe(
+      true
+    );
+    expect(isQuotaExceededError(new Error('dailyLimitExceeded'))).toBe(true);
+    expect(isQuotaExceededError(new Error('rateLimitExceeded'))).toBe(true);
+    expect(isQuotaExceededError(new Error('channelNotFound'))).toBe(false);
+    expect(isQuotaExceededError('nope')).toBe(false);
+  });
+});
+
+describe('fetchAllSubscriptions', () => {
+  it('paginates and charges one unit per page', async () => {
+    mockListSubscribedChannels
+      .mockResolvedValueOnce(subscribedPage([{ channelId: 'UC_a' }], 'page-2'))
+      .mockResolvedValueOnce(subscribedPage([{ channelId: 'UC_b' }]));
+
+    const result = await fetchAllSubscriptions(account);
+
+    expect(result.map.get('UC_a')).toBe('sub-UC_a');
+    expect(result.map.get('UC_b')).toBe('sub-UC_b');
+    expect(result.quotaUnits).toBe(2);
+    expect(mockListSubscribedChannels).toHaveBeenCalledTimes(2);
+    expect(mockListSubscribedChannels).toHaveBeenLastCalledWith(account, 'page-2');
+  });
+});
+
+describe('planBulkSubscriptions', () => {
+  it('only queues channels that actually need a write when subscribing', async () => {
+    mockListSubscribedChannels.mockResolvedValue(subscribedPage([{ channelId: 'UC_already' }]));
+
+    const plan = await planBulkSubscriptions(account, 'subscribe', [
+      { channelId: 'UC_already', title: 'Already' },
+      { channelId: 'UC_new', title: 'New' },
+    ]);
+
+    expect(plan.pending).toEqual([{ channelId: 'UC_new', title: 'New' }]);
+    expect(plan.skipped.map((s) => s.channelId)).toEqual(['UC_already']);
+    expect(plan.estimatedQuotaUnits).toBe(SUBSCRIPTION_WRITE_COST);
+    expect(plan.withinDailyQuota).toBe(true);
+  });
+
+  it('queues only subscribed channels when unsubscribing, carrying the subscription id', async () => {
+    mockListSubscribedChannels.mockResolvedValue(subscribedPage([{ channelId: 'UC_have' }]));
+
+    const plan = await planBulkSubscriptions(account, 'unsubscribe', [
+      { channelId: 'UC_have' },
+      { channelId: 'UC_absent' },
+    ]);
+
+    expect(plan.pending).toEqual([
+      { channelId: 'UC_have', title: 'UC_have', subscriptionId: 'sub-UC_have' },
+    ]);
+    expect(plan.skipped.map((s) => s.channelId)).toEqual(['UC_absent']);
+  });
+
+  it('de-duplicates requested channels', async () => {
+    mockListSubscribedChannels.mockResolvedValue(subscribedPage([]));
+
+    const plan = await planBulkSubscriptions(account, 'subscribe', [
+      { channelId: 'UC_dup' },
+      { channelId: 'UC_dup' },
+    ]);
+
+    expect(plan.pending).toHaveLength(1);
+  });
+
+  it('flags a list that cannot fit in one day of quota', async () => {
+    mockListSubscribedChannels.mockResolvedValue(subscribedPage([]));
+    const channels = Array.from({ length: 257 }, (_, i) => ({ channelId: `UC_${i}` }));
+
+    const plan = await planBulkSubscriptions(account, 'subscribe', channels);
+
+    expect(plan.estimatedQuotaUnits).toBe(257 * SUBSCRIPTION_WRITE_COST);
+    expect(plan.estimatedQuotaUnits).toBeGreaterThan(DEFAULT_DAILY_QUOTA);
+    expect(plan.withinDailyQuota).toBe(false);
+    expect(plan.dailyWriteCapacity).toBe(200);
+  });
+});
+
+describe('executeBulkSubscriptions', () => {
+  it('inserts each pending channel without a pre-flight probe', async () => {
+    mockListSubscribedChannels.mockResolvedValue(subscribedPage([]));
+    mockYtFetch.mockResolvedValue({ id: 'new-sub' });
+
+    const plan = await planBulkSubscriptions(account, 'subscribe', [
+      { channelId: 'UC_one', title: 'One' },
+      { channelId: 'UC_two', title: 'Two' },
+    ]);
+    const result = await executeBulkSubscriptions(account, plan);
+
+    expect(result.succeeded.map((s) => s.channelId)).toEqual(['UC_one', 'UC_two']);
+    expect(result.failed).toEqual([]);
+    expect(result.remaining).toEqual([]);
+    expect(result.quotaUnitsSpent).toBe(2 * SUBSCRIPTION_WRITE_COST);
+    expect(mockYtFetch).toHaveBeenCalledTimes(2);
+    expect(mockYtFetch).toHaveBeenNthCalledWith(1, account, {
+      path: '/subscriptions',
+      method: 'POST',
+      params: { part: 'snippet' },
+      body: { snippet: { resourceId: { kind: 'youtube#channel', channelId: 'UC_one' } } },
+    });
+  });
+
+  it('stops immediately on quota exhaustion and reports what is left', async () => {
+    mockListSubscribedChannels.mockResolvedValue(subscribedPage([]));
+    mockYtFetch
+      .mockResolvedValueOnce({ id: 'sub-1' })
+      .mockRejectedValueOnce(new Error('YouTube API /subscriptions failed (403): quotaExceeded'));
+
+    const plan = await planBulkSubscriptions(account, 'subscribe', [
+      { channelId: 'UC_one' },
+      { channelId: 'UC_two' },
+      { channelId: 'UC_three' },
+    ]);
+    const result = await executeBulkSubscriptions(account, plan);
+
+    expect(result.quotaExceeded).toBe(true);
+    expect(result.succeeded.map((s) => s.channelId)).toEqual(['UC_one']);
+    expect(result.remaining.map((r) => r.channelId)).toEqual(['UC_two', 'UC_three']);
+    // Third channel was never attempted.
+    expect(mockYtFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('records a per-channel failure and keeps going', async () => {
+    mockListSubscribedChannels.mockResolvedValue(subscribedPage([]));
+    mockYtFetch
+      .mockRejectedValueOnce(new Error('YouTube API /subscriptions failed (404): channelNotFound'))
+      .mockResolvedValueOnce({ id: 'sub-2' });
+
+    const plan = await planBulkSubscriptions(account, 'subscribe', [
+      { channelId: 'UC_bad' },
+      { channelId: 'UC_good' },
+    ]);
+    const result = await executeBulkSubscriptions(account, plan);
+
+    expect(result.failed.map((f) => f.channelId)).toEqual(['UC_bad']);
+    expect(result.succeeded.map((s) => s.channelId)).toEqual(['UC_good']);
+    expect(result.quotaExceeded).toBe(false);
+    expect(result.remaining).toEqual([]);
+  });
+
+  it('honours maxWrites so a run can be split across days', async () => {
+    mockListSubscribedChannels.mockResolvedValue(subscribedPage([]));
+    mockYtFetch.mockResolvedValue({ id: 'sub' });
+
+    const plan = await planBulkSubscriptions(account, 'subscribe', [
+      { channelId: 'UC_one' },
+      { channelId: 'UC_two' },
+      { channelId: 'UC_three' },
+    ]);
+    const result = await executeBulkSubscriptions(account, plan, { maxWrites: 2 });
+
+    expect(result.succeeded).toHaveLength(2);
+    expect(result.remaining.map((r) => r.channelId)).toEqual(['UC_three']);
+    expect(mockYtFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('deletes by the subscription id resolved during planning', async () => {
+    mockListSubscribedChannels.mockResolvedValue(subscribedPage([{ channelId: 'UC_have' }]));
+    mockUnsubscribeFromChannel.mockResolvedValue({ subscriptionId: 'sub-UC_have', channelId: 'UC_have' });
+
+    const plan = await planBulkSubscriptions(account, 'unsubscribe', [{ channelId: 'UC_have' }]);
+    const result = await executeBulkSubscriptions(account, plan);
+
+    expect(mockUnsubscribeFromChannel).toHaveBeenCalledWith(account, {
+      subscriptionId: 'sub-UC_have',
+      channelId: 'UC_have',
+    });
+    expect(result.succeeded).toHaveLength(1);
+    expect(mockYtFetch).not.toHaveBeenCalled();
+  });
+
+  it('reports progress for each attempted write', async () => {
+    mockListSubscribedChannels.mockResolvedValue(subscribedPage([]));
+    mockYtFetch.mockResolvedValue({ id: 'sub' });
+    const onProgress = vi.fn();
+
+    const plan = await planBulkSubscriptions(account, 'subscribe', [
+      { channelId: 'UC_one' },
+      { channelId: 'UC_two' },
+    ]);
+    await executeBulkSubscriptions(account, plan, { onProgress });
+
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenLastCalledWith(
+      expect.objectContaining({ channelId: 'UC_two', status: 'ok' }),
+      1,
+      2
+    );
+  });
+});

--- a/src/lib/youtube/bulk.ts
+++ b/src/lib/youtube/bulk.ts
@@ -1,0 +1,301 @@
+/**
+ * Bulk subscribe / unsubscribe against a list of YouTube channel ids.
+ *
+ * The YouTube Data API charges 50 quota units for every `subscriptions.insert`
+ * and `subscriptions.delete`, against a default allowance of 10,000 units per
+ * project per day. That is ~200 writes/day for the whole app, so bulk runs are
+ * planned before they are executed, stop the moment the quota is exhausted, and
+ * always report exactly what is left to do so the run can be resumed tomorrow.
+ */
+
+import { listSubscribedChannels, unsubscribeFromChannel } from './service';
+import { ytFetch } from './client';
+import type { YouTubeAccount } from './types';
+
+/** Quota cost of a single subscriptions.insert or subscriptions.delete. */
+export const SUBSCRIPTION_WRITE_COST = 50;
+/** Quota cost of a single subscriptions.list page. */
+export const SUBSCRIPTION_LIST_COST = 1;
+/** Google's default per-project daily allowance. */
+export const DEFAULT_DAILY_QUOTA = 10_000;
+
+/** Stop paginating existing subscriptions after this many pages (50 per page). */
+const MAX_SUBSCRIPTION_PAGES = 60;
+
+export type BulkAction = 'subscribe' | 'unsubscribe';
+
+export interface BulkChannelInput {
+  channelId: string;
+  title?: string | null;
+}
+
+export interface BulkPlanItem {
+  channelId: string;
+  title: string | null;
+  /** Present for unsubscribes, where the id is already known from the diff. */
+  subscriptionId?: string;
+}
+
+export interface BulkPlan {
+  action: BulkAction;
+  /** Channels that need an API write. */
+  pending: BulkPlanItem[];
+  /** Channels already in the desired state — these cost nothing. */
+  skipped: BulkPlanItem[];
+  /** Quota units the pending writes will consume. */
+  estimatedQuotaUnits: number;
+  /** Units already spent listing existing subscriptions while planning. */
+  planningQuotaUnits: number;
+  /** False when the pending writes exceed a single day's default allowance. */
+  withinDailyQuota: boolean;
+  /** How many writes fit in the default daily allowance. */
+  dailyWriteCapacity: number;
+}
+
+export interface BulkItemResult {
+  channelId: string;
+  title: string | null;
+  status: 'ok' | 'failed';
+  error?: string;
+}
+
+export interface BulkRunResult {
+  action: BulkAction;
+  succeeded: BulkItemResult[];
+  failed: BulkItemResult[];
+  /** Items never attempted — quota ran out, the cap was hit, or it was aborted. */
+  remaining: BulkPlanItem[];
+  quotaUnitsSpent: number;
+  /** True when the run stopped early because YouTube reported quota exhaustion. */
+  quotaExceeded: boolean;
+}
+
+export interface ExecuteBulkOptions {
+  /** Hard cap on writes for this run. Defaults to the whole plan. */
+  maxWrites?: number;
+  /** Called after each attempted write, for streaming progress. */
+  onProgress?: (result: BulkItemResult, index: number, total: number) => void;
+  /** Abort an in-flight run. */
+  signal?: AbortSignal;
+  /** Milliseconds to pause between writes; keeps below the per-second limits. */
+  delayMs?: number;
+}
+
+/**
+ * Detects the 403 `quotaExceeded` / `rateLimitExceeded` family. Continuing
+ * after one of these just burns the rest of the list into failures.
+ */
+export function isQuotaExceededError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message.toLowerCase() : '';
+  return (
+    message.includes('quotaexceeded') ||
+    message.includes('quota exceeded') ||
+    message.includes('dailylimitexceeded') ||
+    message.includes('ratelimitexceeded')
+  );
+}
+
+/** True when the failure is permanent for this channel and should not be retried. */
+function isPermanentChannelError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message.toLowerCase() : '';
+  return (
+    message.includes('subscriptionduplicate') ||
+    message.includes('channelnotfound') ||
+    message.includes('subscribernotfound') ||
+    message.includes('accountclosed') ||
+    message.includes('accountsuspended')
+  );
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) return;
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        reject(new Error('aborted'));
+      },
+      { once: true }
+    );
+  });
+}
+
+/**
+ * Fetch every channel the account is currently subscribed to, as a
+ * channelId -> subscriptionId map. Costs 1 unit per 50 channels.
+ */
+export async function fetchAllSubscriptions(
+  account: YouTubeAccount
+): Promise<{ map: Map<string, string>; titles: Map<string, string>; quotaUnits: number }> {
+  const map = new Map<string, string>();
+  const titles = new Map<string, string>();
+  let pageToken: string | undefined;
+  let quotaUnits = 0;
+
+  for (let page = 0; page < MAX_SUBSCRIPTION_PAGES; page += 1) {
+    const response = await listSubscribedChannels(account, pageToken);
+    quotaUnits += SUBSCRIPTION_LIST_COST;
+
+    for (const item of response.items) {
+      map.set(item.channelId, item.subscriptionId);
+      if (item.title) titles.set(item.channelId, item.title);
+    }
+
+    if (!response.nextPageToken) break;
+    pageToken = response.nextPageToken;
+  }
+
+  return { map, titles, quotaUnits };
+}
+
+/**
+ * Diff the requested channels against what the account already has, so only
+ * real changes cost quota.
+ */
+export async function planBulkSubscriptions(
+  account: YouTubeAccount,
+  action: BulkAction,
+  channels: readonly BulkChannelInput[]
+): Promise<BulkPlan> {
+  const { map: existing, titles, quotaUnits: planningQuotaUnits } = await fetchAllSubscriptions(account);
+
+  const pending: BulkPlanItem[] = [];
+  const skipped: BulkPlanItem[] = [];
+  const seen = new Set<string>();
+
+  for (const channel of channels) {
+    const channelId = channel.channelId.trim();
+    if (!channelId || seen.has(channelId)) continue;
+    seen.add(channelId);
+
+    const title = channel.title ?? titles.get(channelId) ?? null;
+    const subscriptionId = existing.get(channelId);
+    const isSubscribed = subscriptionId !== undefined;
+
+    if (action === 'subscribe') {
+      if (isSubscribed) skipped.push({ channelId, title, subscriptionId });
+      else pending.push({ channelId, title });
+    } else {
+      if (isSubscribed) pending.push({ channelId, title, subscriptionId });
+      else skipped.push({ channelId, title });
+    }
+  }
+
+  const estimatedQuotaUnits = pending.length * SUBSCRIPTION_WRITE_COST;
+  const dailyWriteCapacity = Math.floor(DEFAULT_DAILY_QUOTA / SUBSCRIPTION_WRITE_COST);
+
+  return {
+    action,
+    pending,
+    skipped,
+    estimatedQuotaUnits,
+    planningQuotaUnits,
+    withinDailyQuota: estimatedQuotaUnits + planningQuotaUnits <= DEFAULT_DAILY_QUOTA,
+    dailyWriteCapacity,
+  };
+}
+
+/**
+ * Subscribe without the usual pre-flight existence probe — the plan already
+ * proved this channel is not subscribed, so the extra unit would be wasted.
+ */
+async function insertSubscription(account: YouTubeAccount, channelId: string): Promise<void> {
+  await ytFetch(account, {
+    path: '/subscriptions',
+    method: 'POST',
+    params: { part: 'snippet' },
+    body: {
+      snippet: {
+        resourceId: { kind: 'youtube#channel', channelId },
+      },
+    },
+  });
+}
+
+/**
+ * Run the plan's writes sequentially, stopping cleanly on quota exhaustion or
+ * abort so the caller can resume from `remaining`.
+ */
+export async function executeBulkSubscriptions(
+  account: YouTubeAccount,
+  plan: BulkPlan,
+  options: ExecuteBulkOptions = {}
+): Promise<BulkRunResult> {
+  const { onProgress, signal, delayMs = 0 } = options;
+  const maxWrites = Math.max(0, Math.min(options.maxWrites ?? plan.pending.length, plan.pending.length));
+
+  const succeeded: BulkItemResult[] = [];
+  const failed: BulkItemResult[] = [];
+  let quotaUnitsSpent = 0;
+  let quotaExceeded = false;
+  let index = 0;
+
+  for (; index < maxWrites; index += 1) {
+    if (signal?.aborted) break;
+
+    const item = plan.pending[index];
+    try {
+      if (plan.action === 'subscribe') {
+        await insertSubscription(account, item.channelId);
+      } else {
+        await unsubscribeFromChannel(account, {
+          subscriptionId: item.subscriptionId,
+          channelId: item.channelId,
+        });
+      }
+
+      quotaUnitsSpent += SUBSCRIPTION_WRITE_COST;
+      const result: BulkItemResult = { channelId: item.channelId, title: item.title, status: 'ok' };
+      succeeded.push(result);
+      onProgress?.(result, index, maxWrites);
+    } catch (err) {
+      if (isQuotaExceededError(err)) {
+        // The write did not land, but the attempt still cost its units.
+        quotaUnitsSpent += SUBSCRIPTION_WRITE_COST;
+        quotaExceeded = true;
+        break;
+      }
+
+      quotaUnitsSpent += SUBSCRIPTION_WRITE_COST;
+      const result: BulkItemResult = {
+        channelId: item.channelId,
+        title: item.title,
+        status: 'failed',
+        error: errorMessage(err),
+      };
+      failed.push(result);
+      onProgress?.(result, index, maxWrites);
+
+      // A permanent per-channel error is not a reason to abandon the run.
+      if (!isPermanentChannelError(err)) {
+        // Transient errors get one short backoff before moving on.
+        await sleep(Math.max(delayMs, 250), signal).catch(() => undefined);
+      }
+      continue;
+    }
+
+    if (delayMs > 0 && index < maxWrites - 1) {
+      try {
+        await sleep(delayMs, signal);
+      } catch {
+        index += 1;
+        break;
+      }
+    }
+  }
+
+  return {
+    action: plan.action,
+    succeeded,
+    failed,
+    remaining: plan.pending.slice(index),
+    quotaUnitsSpent,
+    quotaExceeded,
+  };
+}

--- a/src/lib/youtube/channel-list.test.ts
+++ b/src/lib/youtube/channel-list.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { isValidChannelId, parseChannelIds, parseChannelList } from './channel-list';
+
+describe('parseChannelList', () => {
+  it('parses the kagi smallweb line format', () => {
+    const text = [
+      '',
+      'https://www.youtube.com/feeds/videos.xml?channel_id=UC_msctwlIh2cwM8yAtaju1A # Nick Sibicky https://www.youtube.com/channel/UC_msctwlIh2cwM8yAtaju1A',
+      'https://www.youtube.com/feeds/videos.xml?channel_id=UC_RILDt90_cEge-fWOsqGLQ # Aaroncake https://www.youtube.com/@aaroncake',
+    ].join('\n');
+
+    const result = parseChannelList(text);
+
+    expect(result.entries).toEqual([
+      { channelId: 'UC_msctwlIh2cwM8yAtaju1A', title: 'Nick Sibicky' },
+      { channelId: 'UC_RILDt90_cEge-fWOsqGLQ', title: 'Aaroncake' },
+    ]);
+    expect(result.unresolved).toEqual([]);
+    expect(result.duplicateCount).toBe(0);
+  });
+
+  it('strips the trailing channel url from the title but keeps inner text', () => {
+    const result = parseChannelList(
+      'https://www.youtube.com/feeds/videos.xml?channel_id=UC17mJJnvzAa_e9qQqLIfIeQ # Semicolon &amp; Sons https://www.youtube.com/channel/UC17mJJnvzAa_e9qQqLIfIeQ'
+    );
+
+    expect(result.entries[0].title).toBe('Semicolon & Sons');
+  });
+
+  it('keeps non-ascii titles intact', () => {
+    const result = parseChannelList(
+      'https://www.youtube.com/feeds/videos.xml?channel_id=UC_HZvxzC_PWvRKoFznYOfYw # ПРАВКА,СВАРКА АЛЮМИНИЯ. Евгений Иванов https://www.youtube.com/channel/UC_HZvxzC_PWvRKoFznYOfYw'
+    );
+
+    expect(result.entries[0].title).toBe('ПРАВКА,СВАРКА АЛЮМИНИЯ. Евгений Иванов');
+  });
+
+  it('accepts bare channel ids and plain channel urls', () => {
+    const result = parseChannelList(
+      ['UC_msctwlIh2cwM8yAtaju1A', 'https://www.youtube.com/channel/UC_RILDt90_cEge-fWOsqGLQ'].join('\n')
+    );
+
+    expect(parseChannelIds(result.entries.map((e) => e.channelId).join('\n'))).toEqual([
+      'UC_msctwlIh2cwM8yAtaju1A',
+      'UC_RILDt90_cEge-fWOsqGLQ',
+    ]);
+    expect(result.entries[0].title).toBeNull();
+  });
+
+  it('collapses duplicates while preserving first-seen order', () => {
+    const result = parseChannelList(
+      [
+        'UC_msctwlIh2cwM8yAtaju1A',
+        'https://www.youtube.com/channel/UC_msctwlIh2cwM8yAtaju1A',
+        'UC_RILDt90_cEge-fWOsqGLQ',
+      ].join('\n')
+    );
+
+    expect(result.entries.map((e) => e.channelId)).toEqual([
+      'UC_msctwlIh2cwM8yAtaju1A',
+      'UC_RILDt90_cEge-fWOsqGLQ',
+    ]);
+    expect(result.duplicateCount).toBe(1);
+  });
+
+  it('skips blank and comment-only lines', () => {
+    const result = parseChannelList(['', '   ', '# a heading', 'UC_msctwlIh2cwM8yAtaju1A'].join('\n'));
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it('reports handle-only urls as unresolved rather than dropping them', () => {
+    const result = parseChannelList('https://www.youtube.com/@AlphaPhoenixChannel');
+
+    expect(result.entries).toEqual([]);
+    expect(result.unresolved).toEqual(['https://www.youtube.com/@AlphaPhoenixChannel']);
+  });
+
+  it('parses OPML exports', () => {
+    const text = `<?xml version="1.0"?>
+      <opml version="1.0"><body>
+        <outline text="Nick Sibicky" title="Nick Sibicky" type="rss"
+          xmlUrl="https://www.youtube.com/feeds/videos.xml?channel_id=UC_msctwlIh2cwM8yAtaju1A" />
+        <outline text="Aaroncake" xmlUrl="https://www.youtube.com/feeds/videos.xml?channel_id=UC_RILDt90_cEge-fWOsqGLQ" />
+      </body></opml>`;
+
+    const result = parseChannelList(text);
+
+    expect(result.entries).toEqual([
+      { channelId: 'UC_msctwlIh2cwM8yAtaju1A', title: 'Nick Sibicky' },
+      { channelId: 'UC_RILDt90_cEge-fWOsqGLQ', title: 'Aaroncake' },
+    ]);
+  });
+
+  it('returns an empty result for empty input', () => {
+    expect(parseChannelList('')).toEqual({ entries: [], unresolved: [], duplicateCount: 0 });
+    expect(parseChannelList('   \n  ')).toEqual({ entries: [], unresolved: [], duplicateCount: 0 });
+  });
+});
+
+describe('isValidChannelId', () => {
+  it('accepts a well formed id and rejects near misses', () => {
+    expect(isValidChannelId('UC_msctwlIh2cwM8yAtaju1A')).toBe(true);
+    expect(isValidChannelId(' UC_msctwlIh2cwM8yAtaju1A ')).toBe(true);
+    expect(isValidChannelId('UC_tooshort')).toBe(false);
+    expect(isValidChannelId('XX_msctwlIh2cwM8yAtaju1A')).toBe(false);
+    expect(isValidChannelId('')).toBe(false);
+  });
+});

--- a/src/lib/youtube/channel-list.ts
+++ b/src/lib/youtube/channel-list.ts
@@ -1,0 +1,159 @@
+/**
+ * Parsing helpers for bulk YouTube channel lists.
+ *
+ * Supports the formats people actually paste in, notably the Kagi smallweb
+ * list (https://github.com/kagisearch/smallweb/blob/main/smallyt.txt) whose
+ * lines look like:
+ *
+ *   https://www.youtube.com/feeds/videos.xml?channel_id=UCxxx # Title https://www.youtube.com/channel/UCxxx
+ *
+ * Also accepts bare channel ids, /channel/ URLs, and OPML exports.
+ */
+
+/** A YouTube channel id is always `UC` followed by 22 id characters. */
+const CHANNEL_ID_PATTERN = /UC[A-Za-z0-9_-]{22}/;
+const CHANNEL_ID_ANCHORED = /^UC[A-Za-z0-9_-]{22}$/;
+const OPML_XML_URL_PATTERN = /xmlUrl\s*=\s*"([^"]+)"/gi;
+const OPML_TITLE_PATTERN = /(?:title|text)\s*=\s*"([^"]*)"/i;
+/** A trailing ` https://...` on a comment is the channel link, not the title. */
+const TRAILING_URL_PATTERN = /\s+https?:\/\/\S*$/;
+
+export interface ParsedChannelEntry {
+  channelId: string;
+  /** Human readable name when the source provided one. */
+  title: string | null;
+}
+
+export interface ParseChannelListResult {
+  entries: ParsedChannelEntry[];
+  /** Lines that looked like content but carried no resolvable channel id. */
+  unresolved: string[];
+  /** Count of duplicate channel ids collapsed while parsing. */
+  duplicateCount: number;
+}
+
+const HTML_ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+  '&apos;': "'",
+  '&nbsp;': ' ',
+};
+
+function decodeEntities(value: string): string {
+  return value.replace(/&(?:amp|lt|gt|quot|apos|nbsp|#39);/g, (match) => HTML_ENTITIES[match] ?? match);
+}
+
+function cleanTitle(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const withoutUrl = raw.replace(TRAILING_URL_PATTERN, '');
+  const decoded = decodeEntities(withoutUrl).trim();
+  return decoded.length > 0 ? decoded : null;
+}
+
+function extractChannelId(value: string): string | null {
+  const match = CHANNEL_ID_PATTERN.exec(value);
+  return match ? match[0] : null;
+}
+
+/**
+ * `@handle` and `/c/vanity` URLs cannot be turned into a channel id without
+ * spending 100 quota units on a search call, so they are reported as
+ * unresolved rather than silently dropped.
+ */
+function looksLikeContent(line: string): boolean {
+  return line.trim().length > 0;
+}
+
+function parseOpml(text: string): ParseChannelListResult {
+  const entries: ParsedChannelEntry[] = [];
+  const unresolved: string[] = [];
+  const seen = new Set<string>();
+  let duplicateCount = 0;
+
+  // Walk <outline .../> elements so a title can stay paired with its feed url.
+  const outlines = text.match(/<outline\b[^>]*>/gi) ?? [];
+  for (const outline of outlines) {
+    OPML_XML_URL_PATTERN.lastIndex = 0;
+    const urlMatch = OPML_XML_URL_PATTERN.exec(outline);
+    if (!urlMatch) continue;
+
+    const channelId = extractChannelId(urlMatch[1]);
+    if (!channelId) {
+      unresolved.push(urlMatch[1]);
+      continue;
+    }
+    if (seen.has(channelId)) {
+      duplicateCount += 1;
+      continue;
+    }
+    seen.add(channelId);
+    entries.push({
+      channelId,
+      title: cleanTitle(OPML_TITLE_PATTERN.exec(outline)?.[1] ?? null),
+    });
+  }
+
+  return { entries, unresolved, duplicateCount };
+}
+
+/**
+ * Parse a channel list into de-duplicated channel ids, preserving input order.
+ */
+export function parseChannelList(text: string): ParseChannelListResult {
+  if (typeof text !== 'string' || text.trim().length === 0) {
+    return { entries: [], unresolved: [], duplicateCount: 0 };
+  }
+
+  if (text.includes('<opml') || text.includes('<outline')) {
+    return parseOpml(text);
+  }
+
+  const entries: ParsedChannelEntry[] = [];
+  const unresolved: string[] = [];
+  const seen = new Set<string>();
+  let duplicateCount = 0;
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!looksLikeContent(line)) continue;
+
+    // A line that is only a comment carries no subscription target.
+    if (line.startsWith('#')) continue;
+
+    const hashIndex = line.indexOf('#');
+    const target = hashIndex >= 0 ? line.slice(0, hashIndex).trim() : line;
+    const comment = hashIndex >= 0 ? line.slice(hashIndex + 1).trim() : null;
+
+    // Prefer an id from the feed/url portion; fall back to the comment, which
+    // in the smallweb format repeats the canonical channel link.
+    const channelId =
+      extractChannelId(target) ?? (comment ? extractChannelId(comment) : null);
+
+    if (!channelId) {
+      unresolved.push(line);
+      continue;
+    }
+
+    if (seen.has(channelId)) {
+      duplicateCount += 1;
+      continue;
+    }
+    seen.add(channelId);
+
+    entries.push({ channelId, title: cleanTitle(comment) });
+  }
+
+  return { entries, unresolved, duplicateCount };
+}
+
+/** Convenience wrapper returning just the channel ids, in order. */
+export function parseChannelIds(text: string): string[] {
+  return parseChannelList(text).entries.map((entry) => entry.channelId);
+}
+
+export function isValidChannelId(value: string): boolean {
+  return CHANNEL_ID_ANCHORED.test(value.trim());
+}

--- a/src/lib/youtube/resolve-account.ts
+++ b/src/lib/youtube/resolve-account.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared account resolution for YouTube route handlers.
+ *
+ * Route files may only export handlers, so this lives in lib. It mirrors the
+ * explicit-id -> default -> first -> 412 behaviour the existing YouTube routes
+ * already implement inline.
+ */
+
+import { NextResponse } from 'next/server';
+import { getAccountById, listAccountsForUser } from './repository';
+import type { YouTubeAccount } from './types';
+
+export function isResponse(value: YouTubeAccount | Response): value is Response {
+  return value instanceof Response;
+}
+
+export async function resolveYouTubeAccount(
+  userId: string,
+  accountId: string | null
+): Promise<YouTubeAccount | Response> {
+  if (accountId) {
+    const account = await getAccountById(userId, accountId);
+    if (!account) {
+      return NextResponse.json({ error: 'Account not found' }, { status: 404 });
+    }
+    return account;
+  }
+
+  const accounts = await listAccountsForUser(userId);
+  const account = accounts.find((a) => a.isDefault) ?? accounts[0] ?? null;
+  if (!account) {
+    return NextResponse.json(
+      { error: 'no_connected_account', message: 'Connect a YouTube account first.' },
+      { status: 412 }
+    );
+  }
+  return account;
+}


### PR DESCRIPTION
Adds a way to mass subscribe/unsubscribe from a channel list like the [Kagi smallweb feed](https://raw.githubusercontent.com/kagisearch/smallweb/refs/heads/main/smallyt.txt) (257 channels).

## The constraint that shaped this

`subscriptions.insert` and `subscriptions.delete` each cost **50 quota units** against a default **10,000 units/day**. That's ~200 writes/day for the whole project, so the 257-channel list needs **~12,850 units — two days minimum**. It cannot be a single fire-and-forget call.

So every path here: plans before writing, diffs against existing subscriptions so only real changes cost quota, stops the instant YouTube reports exhaustion, and always reports the untouched remainder so the run resumes.

## Three ways to use it

**UI** — `/youtube/bulk`, linked from `/youtube`. Paste a list or load a URL, hit Preview to see the cost, then apply. The list URL is fetched **in the browser**, so the app never becomes an open fetch proxy.

**API** — `POST /api/youtube/subscriptions/bulk`. Dry run by default; writing requires an explicit `dryRun: false`.

**CLI** — `pnpm youtube:bulk`, for the multi-day run:
```bash
pnpm youtube:bulk --email you@example.com --list <url>            # preview
pnpm youtube:bulk --email you@example.com --list <url> --apply    # day 1, 200 writes
pnpm youtube:bulk --email you@example.com --list .youtube-bulk-remaining.txt --apply  # day 2
```

## Notes

- Re-running is always safe — already-subscribed channels are skipped for free, so the resume file is a convenience, not a requirement.
- Bulk skips the per-channel existence probe `subscribeToChannel` does; the plan already established the state, saving 257 wasted calls.
- Adds `quotaExceeded` detection, which the codebase had nowhere — a 403 quota error previously surfaced as a generic 502.
- The parser handles the smallweb format, bare ids, `/channel/` URLs and OPML. `@handle`-only URLs are reported as **unresolved** rather than dropped, since resolving one costs 100 units via search.

## Verification

- Full suite: **188 files, 2601 passed, 0 failed** (33 new tests)
- `tsc --noEmit` clean; eslint 0 errors on new files
- `next build` succeeds, both routes registered
- Parser validated against the real 257-line file: 257 entries, 0 unresolved, 1 duplicate collapsed, Cyrillic titles and `&amp;` intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)