### PR TITLE
Default bulk YouTube runs to 2 writes, and show what a run actually costs

### DIFF
--- a/scripts/youtube-bulk-subscriptions.ts
+++ b/scripts/youtube-bulk-subscriptions.ts
@@ -17,8 +17,12 @@
  *   # See what would happen (default — writes nothing):
  *   pnpm youtube:bulk --email you@example.com --list <url|path>
  *
- *   # Apply, capped to today's quota:
- *   pnpm youtube:bulk --email you@example.com --list <url|path> --apply --max 200
+ *   # Apply a small batch (default --max 2), good for a first real test:
+ *   pnpm youtube:bulk --email you@example.com --list <url|path> --apply
+ *
+ *   # Once it looks right, take a bigger bite. 200 is the whole day's quota
+ *   # for the entire app, so prefer something well under it:
+ *   pnpm youtube:bulk --email you@example.com --list <url|path> --apply --max 50
  *
  *   # Next day, finish the rest:
  *   pnpm youtube:bulk --email you@example.com --list .youtube-bulk-remaining.txt --apply
@@ -32,7 +36,10 @@
  *   --account-id <id>   Explicit bt_youtube_accounts row id.
  *   --action <a>        subscribe (default) | unsubscribe
  *   --apply             Actually write. Without it the script is a dry run.
- *   --max <n>           Cap writes this run. Defaults to the daily capacity (200).
+ *   --max <n>           Cap writes this run. Defaults to 2 — deliberately tiny,
+ *                       because the quota is project-wide and a big run takes
+ *                       YouTube down for every user of the app. 200 writes is
+ *                       the entire daily allowance; raise it knowingly.
  *   --state <path>      Where to write the remainder. Default .youtube-bulk-remaining.txt
  */
 
@@ -41,6 +48,7 @@ import { createClient } from '@supabase/supabase-js';
 import { parseChannelList } from '../src/lib/youtube/channel-list';
 import {
   DEFAULT_DAILY_QUOTA,
+  DEFAULT_MAX_WRITES_PER_RUN,
   SUBSCRIPTION_WRITE_COST,
   executeBulkSubscriptions,
   planBulkSubscriptions,
@@ -122,7 +130,9 @@ async function main(): Promise<void> {
   const apply = flag('apply');
   const statePath = arg('state') ?? DEFAULT_STATE_PATH;
   const dailyCapacity = Math.floor(DEFAULT_DAILY_QUOTA / SUBSCRIPTION_WRITE_COST);
-  const maxWrites = Number(arg('max') ?? dailyCapacity);
+  // Small by default. The allowance is project-wide, so a run large enough to
+  // exhaust it breaks YouTube for every user of the app, not just this caller.
+  const maxWrites = Number(arg('max') ?? DEFAULT_MAX_WRITES_PER_RUN);
   if (!Number.isFinite(maxWrites) || maxWrites <= 0) fail('--max must be a positive number');
 
   const raw = await loadList(listSource!);

--- a/src/app/api/youtube/subscriptions/bulk/maxwrites.integration.test.ts
+++ b/src/app/api/youtube/subscriptions/bulk/maxwrites.integration.test.ts
@@ -1,0 +1,115 @@
+/**
+ * End-to-end check that maxWrites actually caps the number of API writes.
+ *
+ * The existing route test mocks executeBulkSubscriptions, and the bulk test
+ * calls it directly — so neither proves the cap survives the trip through the
+ * route. Only ytFetch and the account lookup are mocked here.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const { mockRequireActiveSubscription, mockGetUserIdFromRequest, mockResolveYouTubeAccount, mockYtFetch } =
+  vi.hoisted(() => ({
+    mockRequireActiveSubscription: vi.fn(),
+    mockGetUserIdFromRequest: vi.fn(),
+    mockResolveYouTubeAccount: vi.fn(),
+    mockYtFetch: vi.fn(),
+  }));
+
+vi.mock('@/lib/subscription/guard', () => ({
+  requireActiveSubscription: mockRequireActiveSubscription,
+}));
+
+vi.mock('@/lib/youtube/request-auth', () => ({
+  getUserIdFromRequest: mockGetUserIdFromRequest,
+}));
+
+vi.mock('@/lib/youtube/resolve-account', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/lib/youtube/resolve-account')>('@/lib/youtube/resolve-account');
+  return { ...actual, resolveYouTubeAccount: mockResolveYouTubeAccount };
+});
+
+// The only seam: every YouTube HTTP call. Everything above it is the real code.
+vi.mock('@/lib/youtube/client', () => ({
+  ytFetch: mockYtFetch,
+}));
+
+import { POST } from './route';
+
+const STUB_VALUE = 'unused-by-mocked-calls';
+
+const manageAccount = {
+  id: 'account-1',
+  userId: 'user-1',
+  googleSub: 'google-sub',
+  email: 'user@example.com',
+  displayName: 'User',
+  avatarUrl: null,
+  accessToken: STUB_VALUE,
+  refreshToken: STUB_VALUE,
+  tokenExpiresAt: '2026-04-20T00:00:00.000Z',
+  scopes: ['openid', 'email', 'https://www.googleapis.com/auth/youtube.force-ssl'],
+  isDefault: true,
+  createdAt: '2026-04-19T00:00:00.000Z',
+  updatedAt: '2026-04-19T00:00:00.000Z',
+};
+
+/** 20 channels, none of them currently subscribed. */
+const channels = Array.from({ length: 20 }, (_, i) => `UC${String(i).padStart(22, 'a')}`);
+
+function writeCalls(): number {
+  return mockYtFetch.mock.calls.filter((call) => call[1]?.method === 'POST').length;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireActiveSubscription.mockResolvedValue(null);
+  mockGetUserIdFromRequest.mockResolvedValue('user-1');
+  mockResolveYouTubeAccount.mockResolvedValue(manageAccount);
+
+  mockYtFetch.mockImplementation(async (_account, options) => {
+    // subscriptions.list during planning: report an empty subscription set.
+    if (!options.method || options.method === 'GET') {
+      return { items: [], nextPageToken: null, prevPageToken: null };
+    }
+    return { id: 'new-sub', snippet: { resourceId: { channelId: 'x' } } };
+  });
+});
+
+function bulkRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/youtube/subscriptions/bulk', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('maxWrites is honoured end to end', () => {
+  it('writes only 2 channels when maxWrites is 2', async () => {
+    const res = await POST(
+      bulkRequest({ action: 'subscribe', channels, dryRun: false, maxWrites: 2 })
+    );
+
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+
+    expect(writeCalls()).toBe(2);
+    expect(payload.succeededCount).toBe(2);
+    expect(payload.remainingCount).toBe(18);
+  });
+
+  it('a dry run performs no writes at all', async () => {
+    const res = await POST(bulkRequest({ action: 'subscribe', channels, dryRun: true }));
+
+    expect(res.status).toBe(200);
+    expect(writeCalls()).toBe(0);
+  });
+
+  it('writes every pending channel when maxWrites is omitted', async () => {
+    await POST(bulkRequest({ action: 'subscribe', channels, dryRun: false }));
+
+    expect(writeCalls()).toBe(20);
+  });
+});

--- a/src/app/youtube/bulk/bulk-content.tsx
+++ b/src/app/youtube/bulk/bulk-content.tsx
@@ -12,6 +12,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { MainLayout } from '@/components/layout';
+import { DEFAULT_MAX_WRITES_PER_RUN, describeRun } from '@/lib/youtube/bulk';
 
 const SMALLWEB_LIST_URL =
   'https://raw.githubusercontent.com/kagisearch/smallweb/refs/heads/main/smallyt.txt';
@@ -66,7 +67,7 @@ export function BulkContent(): React.ReactElement {
   const [listUrl, setListUrl] = useState(SMALLWEB_LIST_URL);
   const [listText, setListText] = useState('');
   const [action, setAction] = useState<Action>('subscribe');
-  const [maxWrites, setMaxWrites] = useState('200');
+  const [maxWrites, setMaxWrites] = useState(String(DEFAULT_MAX_WRITES_PER_RUN));
   const [plan, setPlan] = useState<BulkResponse | null>(null);
   const [result, setResult] = useState<BulkResponse | null>(null);
   const [busy, setBusy] = useState<'idle' | 'fetching' | 'planning' | 'applying'>('idle');
@@ -157,6 +158,7 @@ export function BulkContent(): React.ReactElement {
 
   const noManageAccess = activeAccount !== null && !activeAccount.hasSubscriptionManageAccess;
   const verb = action === 'subscribe' ? 'Subscribe' : 'Unsubscribe';
+  const runSummary = describeRun(plan?.pendingCount ?? 0, Number(maxWrites));
 
   return (
     <MainLayout>
@@ -301,7 +303,11 @@ export function BulkContent(): React.ReactElement {
               action === 'unsubscribe' ? 'bg-red-600' : 'bg-green-600'
             }`}
           >
-            {busy === 'applying' ? 'Applying…' : `${verb} ${plan?.pendingCount ?? 0}`}
+            {busy === 'applying'
+              ? 'Applying…'
+              : runSummary.leftover > 0
+                ? `${verb} ${runSummary.writes} of ${plan?.pendingCount ?? 0}`
+                : `${verb} ${runSummary.writes}`}
           </button>
         </div>
 
@@ -314,14 +320,32 @@ export function BulkContent(): React.ReactElement {
               {plan.skippedCount} already {plan.action === 'subscribe' ? 'subscribed' : 'not subscribed'}
               {plan.unresolved.length > 0 ? ` · ${plan.unresolved.length} lines had no channel id` : ''}
             </div>
-            <div className="mt-1 text-muted-foreground">
-              Estimated quota: {plan.estimatedQuotaUnits.toLocaleString()} of{' '}
-              {plan.dailyQuota.toLocaleString()} units/day
+            <div className="mt-2 border-t border-border pt-2">
+              <span className="font-medium">This run: {runSummary.writes} writes</span>
+              <span className="text-muted-foreground">
+                {' '}
+                — {runSummary.quotaUnits.toLocaleString()} of {plan.dailyQuota.toLocaleString()}{' '}
+                units/day ({Math.round(runSummary.dailyQuotaShare * 100)}% of the daily allowance)
+              </span>
+              {runSummary.leftover > 0 ? (
+                <span className="text-muted-foreground">
+                  {' '}
+                  · {runSummary.leftover} left for later runs
+                </span>
+              ) : null}
             </div>
-            {!plan.withinDailyQuota ? (
+            {runSummary.dailyQuotaShare >= 0.5 ? (
               <div className="mt-2 text-yellow-300">
-                ⚠ This exceeds one day of API quota. Apply up to {plan.dailyWriteCapacity} today, then
-                run it again tomorrow — already-done channels are skipped automatically.
+                ⚠ This run alone uses {Math.round(runSummary.dailyQuotaShare * 100)}% of the daily
+                quota. That allowance is shared by the whole app — spending it here makes YouTube
+                search and subscription browsing fail for everyone until midnight Pacific.
+              </div>
+            ) : null}
+            {plan.pendingCount > runSummary.writes ? (
+              <div className="mt-1 text-muted-foreground">
+                Finishing the list takes ~{Math.ceil(plan.pendingCount / plan.dailyWriteCapacity)} day(s)
+                at the {plan.dailyWriteCapacity}/day ceiling. Re-running is always safe — channels
+                already done are skipped for free.
               </div>
             ) : null}
           </div>

--- a/src/lib/youtube/bulk.test.ts
+++ b/src/lib/youtube/bulk.test.ts
@@ -18,7 +18,9 @@ vi.mock('./service', () => ({
 
 import {
   DEFAULT_DAILY_QUOTA,
+  DEFAULT_MAX_WRITES_PER_RUN,
   SUBSCRIPTION_WRITE_COST,
+  describeRun,
   executeBulkSubscriptions,
   fetchAllSubscriptions,
   isQuotaExceededError,
@@ -263,5 +265,43 @@ describe('executeBulkSubscriptions', () => {
       1,
       2
     );
+  });
+});
+
+describe('describeRun', () => {
+  it('caps the run at maxWrites and reports the leftover', () => {
+    expect(describeRun(257, 2)).toEqual({
+      writes: 2,
+      quotaUnits: 100,
+      leftover: 255,
+      dailyQuotaShare: 100 / DEFAULT_DAILY_QUOTA,
+    });
+  });
+
+  it('never promises more writes than there are pending channels', () => {
+    const summary = describeRun(3, 200);
+
+    expect(summary.writes).toBe(3);
+    expect(summary.leftover).toBe(0);
+  });
+
+  it('shows that 200 writes consumes the entire daily allowance', () => {
+    const summary = describeRun(1000, 200);
+
+    expect(summary.quotaUnits).toBe(DEFAULT_DAILY_QUOTA);
+    expect(summary.dailyQuotaShare).toBe(1);
+  });
+
+  it('treats a blank or invalid cap as zero writes rather than unlimited', () => {
+    expect(describeRun(257, Number.NaN).writes).toBe(0);
+    expect(describeRun(257, 0).writes).toBe(0);
+    expect(describeRun(257, -5).writes).toBe(0);
+  });
+
+  it('keeps the shipped default small enough to be a safe first run', () => {
+    // A regression guard: the original default of 200 spent the whole
+    // project-wide daily quota in a single click.
+    expect(DEFAULT_MAX_WRITES_PER_RUN).toBeLessThanOrEqual(10);
+    expect(describeRun(257, DEFAULT_MAX_WRITES_PER_RUN).dailyQuotaShare).toBeLessThan(0.1);
   });
 });

--- a/src/lib/youtube/bulk.ts
+++ b/src/lib/youtube/bulk.ts
@@ -19,8 +19,49 @@ export const SUBSCRIPTION_LIST_COST = 1;
 /** Google's default per-project daily allowance. */
 export const DEFAULT_DAILY_QUOTA = 10_000;
 
+/**
+ * Default writes per run.
+ *
+ * Deliberately tiny. The daily quota is per *project*, not per user, so a run
+ * big enough to use it up takes YouTube search and subscription browsing down
+ * with it for everyone until midnight Pacific. Raising this is a decision the
+ * operator makes per run, with the cost shown, rather than a default they
+ * inherit by clicking once.
+ */
+export const DEFAULT_MAX_WRITES_PER_RUN = 2;
+
 /** Stop paginating existing subscriptions after this many pages (50 per page). */
 const MAX_SUBSCRIPTION_PAGES = 60;
+
+export interface RunSummary {
+  /** Writes this run will actually attempt. */
+  writes: number;
+  /** Quota units those writes cost. */
+  quotaUnits: number;
+  /** Pending channels this run will not reach. */
+  leftover: number;
+  /** Share of a full day's project-wide allowance this run consumes, 0-1. */
+  dailyQuotaShare: number;
+}
+
+/**
+ * What a run will actually do, given the plan and the cap. Kept here rather
+ * than in the UI so the number on the button cannot drift from the number the
+ * executor uses.
+ */
+export function describeRun(pendingCount: number, maxWrites: number): RunSummary {
+  const safePending = Math.max(0, Math.floor(pendingCount));
+  const safeMax = Number.isFinite(maxWrites) && maxWrites > 0 ? Math.floor(maxWrites) : 0;
+  const writes = Math.min(safePending, safeMax);
+  const quotaUnits = writes * SUBSCRIPTION_WRITE_COST;
+
+  return {
+    writes,
+    quotaUnits,
+    leftover: safePending - writes,
+    dailyQuotaShare: quotaUnits / DEFAULT_DAILY_QUOTA,
+  };
+}
 
 export type BulkAction = 'subscribe' | 'unsubscribe';
 


### PR DESCRIPTION
Follow-up to #178. Anthony ran a bulk subscribe and exhausted the YouTube daily quota, and reported that the "max writes" field seemed to have no effect.

## The cap was working; the default and the label were the problem

An end-to-end test through the real route (only `ytFetch` mocked) confirms `maxWrites: 2` issues **exactly 2** writes. Nothing was ignoring the field.

Two real defects made it look otherwise:

**1. The default was 200 — the whole day's quota, in one click.** At 50 units per write, 200 writes is exactly the 10,000-unit daily allowance. And that allowance is **per project, not per user**, so spending it here also breaks YouTube search and subscription browsing for every other user of the app until midnight Pacific. That default was indefensible and is the actual cause of the quota loss.

**2. The button ignored the cap.** It rendered `Subscribe 257` from the plan's pending count regardless of `maxWrites`, so setting the field to 2 changed nothing visible before the click — exactly the "no effect" that was reported.

## Changes

- `DEFAULT_MAX_WRITES_PER_RUN = 2`, shared by the UI field and the CLI `--max` flag (which had the identical 200 default).
- `describeRun()` computes writes / quota / leftover in one tested place, so the button label can't drift from what the executor does. The button now reads **"Subscribe 2 of 257"**.
- The plan panel now shows this run's cost and its share of the daily quota, warns above 50%, and states how many days the full list needs.
- Regression test fails if the default ever climbs back above 10.

## Verification

- Full suite **189 files / 2609 passed**, 0 failed (8 new tests)
- New `maxwrites.integration.test.ts` covers the route→service path the old tests left as a gap: the route test mocked the executor and the service test called it directly, so nothing proved the cap survived the trip between them
- `tsc --noEmit` clean, eslint clean on changed files, `next build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)