### PR TITLE
deps: name autoblog by its tarball, so Dependabot cannot resolve it over SSH

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@alpacahq/alpaca-trade-api": "^3.1.3",
     "@mozilla/readability": "^0.6.0",
     "@noriginmedia/norigin-spatial-navigation": "^3.0.0",
-    "@profullstack/autoblog": "github:profullstack/autoblog#75e54af",
+    "@profullstack/autoblog": "https://codeload.github.com/profullstack/autoblog/tar.gz/75e54af",
     "@profullstack/emailer": "^1.0.1",
     "@profullstack/referrals": "^0.1.0",
     "@profullstack/stack": "^0.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
         specifier: ^3.0.0
         version: 3.1.0(react@19.2.5)
       '@profullstack/autoblog':
-        specifier: github:profullstack/autoblog#75e54af
+        specifier: https://codeload.github.com/profullstack/autoblog/tar.gz/75e54af
         version: https://codeload.github.com/profullstack/autoblog/tar.gz/75e54af
       '@profullstack/emailer':
         specifier: ^1.0.1


### PR DESCRIPTION
Every Dependabot PR on this repo is failing, and none of them fail for anything they changed. **`pnpm install` dies before a test runs**, which is why Lint & Type Check, Run Tests and Security Audit all go red together on #181 and #182:

```
git clone git@github.com:profullstack/autoblog.git
fatal: Could not read from remote repository.   → exit 128
```

### Why master is green and the Dependabot branches are not

`package.json` said `"@profullstack/autoblog": "github:profullstack/autoblog#75e54af"` on every branch. That shorthand is the problem — pnpm may resolve it either way, and it resolved differently once the lockfile was regenerated:

| branch | resolved to | CI |
| --- | --- | --- |
| `master` | `https://codeload.github.com/.../tar.gz/75e54af` | green |
| #181 / #182 | `git+https://git@github.com:profullstack/autoblog.git` | red |

A GitHub Actions runner has no key for `git@github.com`, and no reason to have one — **the repository is public**. So the SSH resolution can never work in CI, and it will come back on every future Dependabot PR as long as the shorthand is there.

### The fix

Name the tarball. There is then nothing left to re-resolve: the specifier is the URL that was already working, and any future lockfile regeneration produces the same thing instead of a coin flip.

- resolved commit unchanged at `75e54af`
- **zero** occurrences of `git@github.com` left anywhere in `pnpm-lock.yaml`
- two lines changed in total

### Verified

- the tarball answers **HTTP 200 to an unauthenticated request** — exactly what a runner does
- `pnpm install --frozen-lockfile` completes, with `@profullstack/autoblog` installed
- `tsc --noEmit` passes and the full suite is green — **189 files, 2,609 tests passed, 7 skipped**

This unblocks #181 and #182 once they pick up master. Note #182 is the *major* group (14 packages), so it may still have real failures of its own once install works — this only removes the failure that was masking everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
