### PR TITLE
fix(rss): dedupe items by guid before the batch upsert

### DIFF
--- a/src/lib/rss-reader/repository.test.ts
+++ b/src/lib/rss-reader/repository.test.ts
@@ -183,6 +183,34 @@ describe('upsertFeedItems', () => {
     expect(written.map((row) => row.guid)).toEqual(['guid-1', 'guid-0']);
   });
 
+  it('sends one row per guid, so a repeated guid cannot break the upsert', async () => {
+    const items = [
+      parsedItem(0, '2026-08-01T00:00:00.000Z'),
+      { ...parsedItem(1, '2026-08-03T00:00:00.000Z'), guid: 'guid-0', title: 'Newer duplicate' },
+      parsedItem(2, '2026-08-02T00:00:00.000Z'),
+    ];
+
+    await upsertFeedItems('feed-1', items);
+
+    const written = upsert.mock.calls[0][0] as Array<{ guid: string; title: string }>;
+    expect(written.map((row) => row.guid)).toEqual(['guid-0', 'guid-2']);
+    // The newest copy of a repeated guid wins.
+    expect(written[0].title).toBe('Newer duplicate');
+  });
+
+  it('fills the cap with distinct articles when the feed repeats guids', async () => {
+    const distinct = Array.from({ length: MAX_ITEMS_PER_FEED }, (_, index) =>
+      parsedItem(index, new Date(Date.UTC(2026, 0, 1) + index * 86_400_000).toISOString())
+    );
+    const items = [...distinct, ...distinct];
+
+    await upsertFeedItems('feed-1', items);
+
+    const written = upsert.mock.calls[0][0] as Array<{ guid: string }>;
+    expect(written).toHaveLength(MAX_ITEMS_PER_FEED);
+    expect(new Set(written.map((row) => row.guid)).size).toBe(MAX_ITEMS_PER_FEED);
+  });
+
   it('does nothing when the feed has no articles', async () => {
     await upsertFeedItems('feed-1', []);
 

--- a/src/lib/rss-reader/repository.ts
+++ b/src/lib/rss-reader/repository.ts
@@ -281,6 +281,22 @@ function publishedTime(item: ParsedRssItem): number {
 }
 
 /**
+ * Drops repeat guids, keeping the first copy seen. A feed that reuses a guid —
+ * or that has no guid and no link, so several entries collapse onto the same
+ * title:date fallback — would otherwise send Postgres two rows with the same
+ * (feed_id, guid) in one statement, which fails with "ON CONFLICT DO UPDATE
+ * command cannot affect row a second time".
+ */
+function dedupeByGuid(items: ParsedRssItem[]): ParsedRssItem[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    if (seen.has(item.guid)) return false;
+    seen.add(item.guid);
+    return true;
+  });
+}
+
+/**
  * Stores a feed's newest MAX_ITEMS_PER_FEED articles and prunes whatever the
  * feed has accumulated past that. Saved articles are never pruned — the delete
  * would cascade to rss_item_states and take the bookmark with it.
@@ -288,7 +304,12 @@ function publishedTime(item: ParsedRssItem): number {
 export async function upsertFeedItems(feedId: string, items: ParsedRssItem[]): Promise<RssItem[]> {
   if (items.length === 0) return [];
 
-  const newest = [...items].sort((a, b) => publishedTime(b) - publishedTime(a)).slice(0, MAX_ITEMS_PER_FEED);
+  // Dedupe before the slice so a feed full of repeats still stores
+  // MAX_ITEMS_PER_FEED distinct articles.
+  const newest = dedupeByGuid([...items].sort((a, b) => publishedTime(b) - publishedTime(a))).slice(
+    0,
+    MAX_ITEMS_PER_FEED
+  );
 
   const { data, error } = await db()
     .from(ITEMS_TABLE)


### PR DESCRIPTION
## Problem

Adding or re-adding a feed failed with:

```
Failed to upsert RSS items: ON CONFLICT DO UPDATE command cannot affect row a second time
```

`upsertFeedItems` sends the whole batch as one `INSERT ... ON CONFLICT (feed_id, guid) DO UPDATE`. Postgres refuses to update the same row twice inside a single statement, so if the batch contains two items with the same guid the entire upsert aborts and the feed never saves.

Feeds reach that state two ways:

1. They reuse a guid outright across entries.
2. They publish no `<guid>`/`<id>` **and** no `<link>`, so `stableGuid` in `parser.ts` falls back to `` `${title}:${publishedAt ?? ''}` `` — and several entries collapse onto the same key.

## Fix

Dedupe by guid in `upsertFeedItems`:

- **After** the newest-first sort, so the newest copy of a repeated guid is the one that wins.
- **Before** the `MAX_ITEMS_PER_FEED` slice, so a feed full of repeats still stores a full page of *distinct* articles rather than a page padded with duplicates.

## Tests

Two regression tests added; both fail on `master` and pass here:

- `sends one row per guid, so a repeated guid cannot break the upsert`
- `fills the cap with distinct articles when the feed repeats guids`

Full suite: 2611 passed, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)