### PR TITLE
ci: stop a stalled apt mirror from hanging the whole pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
   lint:
     name: Lint & Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -51,6 +52,7 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     services:
       redis:
         image: redis:7-alpine
@@ -75,8 +77,30 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
 
+      # Some tests spawn ffmpeg for real, so it has to be present. Do not use a
+      # bare `apt-get update && apt-get install`: when the runner's apt mirror
+      # stalls, that call hangs until the job's own timeout kills it — a 15+
+      # minute red build that has nothing to do with the code under test.
+      # Skip the install when the runner image already ships ffmpeg, and give
+      # every apt call a deadline so a stalled mirror costs a retry, not the job.
       - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+        run: |
+          set -u
+          if command -v ffmpeg >/dev/null 2>&1; then
+            echo "ffmpeg already present: $(ffmpeg -version | head -1)"
+            exit 0
+          fi
+          for attempt in 1 2 3; do
+            if sudo timeout 180 apt-get update &&
+               sudo timeout 300 apt-get install -y --no-install-recommends ffmpeg; then
+              ffmpeg -version | head -1
+              exit 0
+            fi
+            echo "::warning::ffmpeg install attempt ${attempt}/3 failed (apt mirror stalled?)"
+            sleep $((attempt * 15))
+          done
+          echo "::error::could not install ffmpeg after 3 attempts"
+          exit 1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -105,6 +129,7 @@ jobs:
   build:
     name: Build Application
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [lint, test]
     steps:
       - name: Checkout code
@@ -147,6 +172,7 @@ jobs:
   security:
     name: Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v7


### PR DESCRIPTION
Every PR and every push to master is currently going red — or worse,
hanging — on something unrelated to the code.

## The failure

`Install ffmpeg` runs a bare `apt-get update && apt-get install -y ffmpeg`
(via `sudo`). When the runner's apt mirror stalls, that call blocks
indefinitely. There is no `timeout-minutes` anywhere in this workflow, so the
job does not fail — it just sits there. One run stayed wedged for over an hour.

That matters more than a red check, because `deploy-droplet.yml` gates on:

```yaml
github.event.workflow_run.conclusion == 'success'
```

A CI run that never concludes successfully means **deploy is silently
skipped**. That is why #186 shows `Deploy to Droplet: skipped`, and why
production is still serving `29db3ff1` despite three merges since.

Master's own run [32225327385](https://github.com/profullstack/media-streamer/actions/runs/32225327385)
died this way at 06:53 today, and it took both open Dependabot PRs down with
it. Nothing was wrong with any of that code.

## The fix

- **Skip the install** when the runner image already ships ffmpeg — on most
  images this turns a network round trip into a version print.
- **Bound every apt call** (180s for `update`, 300s for `install`) and retry
  three times with a backoff. A stalled mirror now costs a retry, not the job.
- **Add `timeout-minutes` to all four jobs** (lint 15, test 25, build 20,
  security 15), so nothing in this workflow can hang for hours again
  regardless of cause. A job that dies at 25 minutes is a bad build; a job
  that hangs indefinitely is a blocked deploy pipeline.

## Verified

Both branches of the step were extracted from the YAML and executed:

- preinstalled ffmpeg → prints the version, exits 0
- install failing → three warnings with backoff, then `::error::` and exit 1

The workflow parses as valid YAML and every job carries a timeout.

## Not covered here

`test.yml` installs ffmpeg identically and needs the same treatment, but it
is sh1pt-fleet-managed (`pack: node-pnpm-test@1.1.0`), so an in-repo edit
would be overwritten — that fix belongs in the pack. It does not gate
deploys, so it does not block this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
