### PR TITLE
Seedboxes: add a torrent by hand, from a magnet or a .torrent

### DIFF
--- a/src/app/api/seedbox/add/route.ts
+++ b/src/app/api/seedbox/add/route.ts
@@ -1,0 +1,112 @@
+/**
+ * POST /api/seedbox/add — hand the seedbox a torrent by hand.
+ *
+ * Everything else that reaches a seedbox comes from the index: you find a
+ * torrent on the site and press send. This is the other way in, for content the
+ * index has never seen — your own release, something a friend sent you, a
+ * .torrent file on your disk.
+ *
+ * Two shapes of input, one path out. A magnet goes straight through. A .torrent
+ * is read for its infohash, name and announce list and turned into a magnet,
+ * which is what every seedbox transport already speaks — so this adds a way in
+ * without adding a second way to send.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getCurrentUser } from '@/lib/auth';
+import {
+  hasSeedbox,
+  isValidMagnet,
+  loadSeedboxForRequest,
+  sendTorrentToSeedbox,
+  type SeedboxTransport,
+} from '@/lib/seedbox';
+import { MAX_TORRENT_BYTES, magnetFor, readTorrent } from '@/lib/seedbox/torrent-file';
+
+interface AddBody {
+  magnet?: unknown;
+  torrent?: unknown;
+  name?: unknown;
+  seedboxId?: unknown;
+  transport?: unknown;
+}
+
+function isTransport(value: unknown): value is SeedboxTransport {
+  return value === 'http' || value === 'ssh';
+}
+
+/**
+ * The uploaded .torrent, as bytes.
+ *
+ * A data: URI prefix is stripped because that is what FileReader.readAsDataURL
+ * hands the browser, and making the client remember to remove it is a bug
+ * waiting to be written once per caller. Buffer.from ignores characters it
+ * cannot decode rather than throwing, so the length check is what separates a
+ * real upload from a pasted sentence.
+ */
+function decodeTorrent(value: unknown): Buffer | null {
+  if (typeof value !== 'string') return null;
+  const base64 = value.replace(/^data:[^,]*,/, '').trim();
+  if (!base64) return null;
+  // 4 base64 chars per 3 bytes; refuse before allocating rather than after.
+  if (base64.length > Math.ceil((MAX_TORRENT_BYTES * 4) / 3)) return null;
+  const bytes = Buffer.from(base64, 'base64');
+  return bytes.length > 0 ? bytes : null;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  const body = (await request.json().catch(() => ({}))) as AddBody;
+  const seedboxId = typeof body.seedboxId === 'string' ? body.seedboxId : null;
+
+  const config = await loadSeedboxForRequest(user.id, seedboxId);
+  if (!hasSeedbox(config)) {
+    return NextResponse.json(
+      { error: 'No seedbox is connected. Add one in Seedboxes → Setup.' },
+      { status: 403 }
+    );
+  }
+
+  let magnet: string;
+  let name = typeof body.name === 'string' ? body.name.trim() : '';
+
+  const uploaded = decodeTorrent(body.torrent);
+  if (uploaded) {
+    const summary = readTorrent(uploaded);
+    if (!summary) {
+      return NextResponse.json(
+        { error: "That file isn't a readable .torrent" },
+        { status: 400 }
+      );
+    }
+    magnet = magnetFor(summary);
+    // The torrent's own name beats anything the form guessed from a filename.
+    name = summary.name;
+  } else if (isValidMagnet(body.magnet)) {
+    magnet = body.magnet.trim();
+  } else {
+    return NextResponse.json(
+      { error: 'Paste a magnet link, or choose a .torrent file' },
+      { status: 400 }
+    );
+  }
+
+  const transport = isTransport(body.transport) ? body.transport : undefined;
+  const result = await sendTorrentToSeedbox(magnet, name, transport, config);
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.message, transport: result.transport },
+      { status: 502 }
+    );
+  }
+
+  return NextResponse.json(
+    { success: true, transport: result.transport, message: result.message, name, magnet },
+    { status: 200 }
+  );
+}

--- a/src/app/seedboxes/add-torrent.tsx
+++ b/src/app/seedboxes/add-torrent.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+/**
+ * Seedboxes → Add
+ *
+ * The way in for content the index has never seen. Everything else that reaches
+ * a seedbox is found on the site first and sent with a button; this is for your
+ * own release, a magnet somebody handed you, or a .torrent sitting on your disk.
+ *
+ * Both inputs end up as one POST, because the server turns a .torrent into a
+ * magnet and every transport already speaks magnets.
+ * See {@link file://../api/seedbox/add/route.ts}.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+import { CheckIcon, LinkIcon, LoadingSpinner, PlusIcon } from '@/components/ui/icons';
+
+interface Box {
+  id: string | null;
+  name: string | null;
+  isDefault: boolean;
+}
+
+interface Result {
+  ok: boolean;
+  message: string;
+}
+
+/** A .torrent as base64, without the data: prefix the API would have to strip. */
+function readAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('Could not read that file'));
+    reader.onload = () => {
+      const result = String(reader.result ?? '');
+      resolve(result.replace(/^data:[^,]*,/, ''));
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+export function AddTorrent(): React.ReactElement {
+  const [boxes, setBoxes] = useState<Box[]>([]);
+  const [seedboxId, setSeedboxId] = useState('');
+  const [magnet, setMagnet] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<Result | null>(null);
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch('/api/account/seedboxes', { cache: 'no-store' })
+      .then((res) => (res.ok ? res.json() : { seedboxes: [] }))
+      .then((data: { seedboxes?: Box[] }) => {
+        if (!cancelled) setBoxes(data.seedboxes ?? []);
+      })
+      .catch(() => {
+        // The picker is a convenience; without it the account default is used,
+        // which is what every send did before an account could have several.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const reset = useCallback((): void => {
+    setMagnet('');
+    setFile(null);
+    if (fileInput.current) fileInput.current.value = '';
+  }, []);
+
+  const submit = useCallback(async (): Promise<void> => {
+    setBusy(true);
+    setResult(null);
+    try {
+      const body: Record<string, string> = {};
+      if (seedboxId) body.seedboxId = seedboxId;
+      if (file) {
+        body.torrent = await readAsBase64(file);
+        body.name = file.name.replace(/\.torrent$/i, '');
+      } else {
+        body.magnet = magnet.trim();
+      }
+
+      const res = await fetch('/api/seedbox/add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = (await res.json().catch(() => ({}))) as { message?: string; error?: string };
+      if (res.ok) {
+        setResult({ ok: true, message: data.message ?? 'Sent to seedbox' });
+        reset();
+      } else {
+        setResult({ ok: false, message: data.error ?? `Failed (${res.status})` });
+      }
+    } catch (error) {
+      setResult({ ok: false, message: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setBusy(false);
+    }
+  }, [file, magnet, reset, seedboxId]);
+
+  // A file wins over a pasted magnet, so the button says which one it will send
+  // rather than leaving the operator to guess when both are filled in.
+  const canSubmit = !busy && (file != null || magnet.trim().length > 0);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h2 className="text-lg font-semibold text-text-primary">Add a torrent</h2>
+        <p className="mt-1 text-sm text-text-secondary">
+          Paste a magnet link, or upload a .torrent file. It goes straight to your seedbox and
+          keeps seeding — nothing here has to be in the index first.
+        </p>
+      </div>
+
+      {boxes.length > 1 && (
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-text-primary">Seedbox</span>
+          <select
+            value={seedboxId}
+            onChange={(e) => setSeedboxId(e.target.value)}
+            className="rounded-lg border border-border bg-bg-secondary px-3 py-2 text-sm text-text-primary"
+          >
+            <option value="">Default</option>
+            {boxes.map((box) => (
+              <option key={box.id ?? 'default'} value={box.id ?? ''}>
+                {box.name ?? 'Unnamed'}
+                {box.isDefault ? ' (default)' : ''}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      <label className="flex flex-col gap-2">
+        <span className="flex items-center gap-2 text-sm font-medium text-text-primary">
+          <LinkIcon size={16} /> Magnet link
+        </span>
+        <textarea
+          value={magnet}
+          onChange={(e) => setMagnet(e.target.value)}
+          placeholder="magnet:?xt=urn:btih:…"
+          rows={3}
+          disabled={file != null}
+          className={cn(
+            'w-full resize-y rounded-lg border border-border bg-bg-secondary px-3 py-2 font-mono text-xs text-text-primary',
+            file != null && 'opacity-50'
+          )}
+        />
+      </label>
+
+      <label className="flex flex-col gap-2">
+        <span className="text-sm font-medium text-text-primary">…or a .torrent file</span>
+        <input
+          ref={fileInput}
+          type="file"
+          accept=".torrent,application/x-bittorrent"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+          className="text-sm text-text-secondary file:mr-3 file:rounded-lg file:border-0 file:bg-bg-hover file:px-3 file:py-2 file:text-sm file:text-text-primary"
+        />
+        {file ? <span className="text-xs text-text-secondary">
+            {file.name} — the magnet is built from the file, so the link box is ignored
+          </span> : null}
+      </label>
+
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => void submit()}
+          disabled={!canSubmit}
+          className={cn(
+            'flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors',
+            canSubmit
+              ? 'bg-accent-primary text-white hover:opacity-90'
+              : 'cursor-not-allowed bg-bg-hover text-text-secondary'
+          )}
+        >
+          {busy ? <LoadingSpinner size={16} /> : <PlusIcon size={16} />}
+          {busy ? 'Sending…' : 'Send to seedbox'}
+        </button>
+
+        {result ? <span
+            className={cn(
+              'flex items-center gap-2 text-sm',
+              result.ok ? 'text-green-500' : 'text-red-500'
+            )}
+          >
+            {result.ok ? <CheckIcon size={16} /> : null}
+            {result.message}
+          </span> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/app/seedboxes/seedbox-tabs.tsx
+++ b/src/app/seedboxes/seedbox-tabs.tsx
@@ -10,15 +10,17 @@
 
 import { useState } from 'react';
 import { cn } from '@/lib/utils';
-import { DownloadIcon, SettingsIcon, CreditCardIcon } from '@/components/ui/icons';
+import { DownloadIcon, PlusIcon, SettingsIcon, CreditCardIcon } from '@/components/ui/icons';
+import { AddTorrent } from './add-torrent';
 import { SeedboxManager } from './seedbox-manager';
 import { TorlinkStatus } from './torlink-status';
 import { RentOut } from './rent-out';
 
-type SeedboxTab = 'setup' | 'status' | 'rent';
+type SeedboxTab = 'setup' | 'add' | 'status' | 'rent';
 
 const TABS: { id: SeedboxTab; label: string; icon: typeof SettingsIcon }[] = [
   { id: 'setup', label: 'Setup', icon: SettingsIcon },
+  { id: 'add', label: 'Add', icon: PlusIcon },
   { id: 'status', label: 'Torlink status', icon: DownloadIcon },
   { id: 'rent', label: 'Rent Out', icon: CreditCardIcon },
 ];
@@ -48,6 +50,7 @@ export function SeedboxTabs(): React.ReactElement {
 
       <div className="min-w-0 flex-1">
         {tab === 'setup' && <SeedboxManager />}
+        {tab === 'add' && <AddTorrent />}
         {tab === 'status' && <TorlinkStatus />}
         {tab === 'rent' && <RentOut />}
       </div>

--- a/src/lib/seedbox/torrent-file.test.ts
+++ b/src/lib/seedbox/torrent-file.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+
+import { magnetFor, readTorrent, spanEnd } from './torrent-file';
+
+/* A minimal bencoder, so the fixtures read as structure rather than as hex. */
+const bstr = (s: string): string => `${Buffer.byteLength(s)}:${s}`;
+
+const INFO = `d6:lengthi12e4:name${bstr('thing.txt')}12:piece lengthi16384ee`;
+const TORRENT = Buffer.from(
+  `d8:announce${bstr('udp://one.test:1337/announce')}13:announce-listll${bstr('udp://one.test:1337/announce')}el${bstr('wss://two.test')}ee4:info${INFO}5:extra${bstr('after')}e`,
+  'utf8'
+);
+
+describe('spanEnd', () => {
+  it('finds the end of each bencoded shape', () => {
+    expect(spanEnd(Buffer.from('i42e'), 0)).toBe(4);
+    expect(spanEnd(Buffer.from('4:spam'), 0)).toBe(6);
+    expect(spanEnd(Buffer.from('l4:spami1ee'), 0)).toBe(11);
+    expect(spanEnd(Buffer.from('d3:onei1ee'), 0)).toBe(10);
+  });
+});
+
+describe('readTorrent', () => {
+  /*
+   * The assertion the infohash depends on.
+   *
+   * It is a SHA-1 over the ORIGINAL bytes of the info dictionary, so the span
+   * has to stop exactly at its end. Take one byte too many or too few and the
+   * hash is for a torrent that does not exist -- a magnet that looks perfectly
+   * well-formed and finds nobody, which is the worst way for this to fail.
+   */
+  it('hashes the info dictionary verbatim, and nothing after it', () => {
+    const expected = createHash('sha1').update(Buffer.from(INFO, 'utf8')).digest('hex');
+    expect(readTorrent(TORRENT)?.infoHash).toBe(expected);
+  });
+
+  it('reads the name from inside the info dictionary', () => {
+    expect(readTorrent(TORRENT)?.name).toBe('thing.txt');
+  });
+
+  /*
+   * Trackers have to survive: a torrent that is not on the public DHT sits at
+   * zero peers forever without them, and on a private tracker the passkey that
+   * makes an announce work at all lives inside that URL.
+   */
+  it('collects announce and every tier of announce-list, without duplicates', () => {
+    const trackers = readTorrent(TORRENT)?.trackers ?? [];
+    expect(trackers).toContain('udp://one.test:1337/announce');
+    expect(trackers).toContain('wss://two.test');
+    // `announce` repeats the first tier of `announce-list` in most torrents.
+    expect(trackers.filter((t) => t === 'udp://one.test:1337/announce')).toHaveLength(1);
+  });
+
+  /*
+   * Null, not a throw: this runs on a file somebody picked in a file dialog,
+   * where "that is not a torrent" is an ordinary thing to have happened and
+   * deserves a sentence rather than a stack trace.
+   */
+  it('returns null for anything that is not a torrent', () => {
+    expect(readTorrent(Buffer.from('hello world'))).toBeNull();
+    expect(readTorrent(Buffer.alloc(0))).toBeNull();
+    expect(readTorrent(Buffer.from('d8:announce'))).toBeNull();
+  });
+
+  it('refuses a file too large to be metadata', () => {
+    expect(readTorrent(Buffer.alloc(17 * 1024 * 1024, 0x64))).toBeNull();
+  });
+});
+
+describe('magnetFor', () => {
+  it('carries the hash, the name and every tracker', () => {
+    const magnet = magnetFor({ infoHash: 'a'.repeat(40), name: 'my thing', trackers: ['udp://a'] });
+    expect(magnet).toContain(`xt=urn:btih:${'a'.repeat(40)}`);
+    expect(magnet).toContain('dn=my%20thing');
+    // Encoded, or the tracker's own ? and & would be read as magnet parameters.
+    expect(magnet).toContain(encodeURIComponent('udp://a'));
+  });
+});

--- a/src/lib/seedbox/torrent-file.ts
+++ b/src/lib/seedbox/torrent-file.ts
@@ -1,0 +1,136 @@
+/**
+ * Reading an uploaded .torrent, without a bencode dependency.
+ *
+ * The Seedboxes page lets you hand torlink a torrent you already have, which
+ * means the server has to answer two questions about a file a browser uploaded:
+ * what is its infohash, and what should it be called. Both live in the
+ * bencoded `info` dictionary.
+ *
+ * A parser is not needed for that. Bencode is four shapes and every one of them
+ * says where it ends, so finding the span of one key's value is a scan rather
+ * than a decode -- and a scan is what the infohash requires anyway. It is a
+ * SHA-1 over the ORIGINAL bytes of that dictionary, so decoding and re-encoding
+ * would change the hash the moment a client wrote a key in an order or a form
+ * we did not reproduce, and produce a magnet for a torrent that does not exist.
+ */
+
+import { createHash } from 'node:crypto';
+
+/** A .torrent is metadata, not payload: even a huge one stays in low megabytes. */
+export const MAX_TORRENT_BYTES = 16 * 1024 * 1024;
+
+const DICT = 0x64; // 'd'
+const LIST = 0x6c; // 'l'
+const INT = 0x69; // 'i'
+const END = 0x65; // 'e'
+const COLON = 0x3a; // ':'
+
+/** The end offset of the bencoded value starting at `at`. */
+export function spanEnd(buf: Buffer, at: number): number {
+  const byte = buf[at];
+  if (byte === undefined) throw new Error('truncated torrent');
+
+  if (byte === INT) {
+    const end = buf.indexOf(END, at + 1);
+    if (end === -1) throw new Error('truncated torrent');
+    return end + 1;
+  }
+
+  if (byte === LIST || byte === DICT) {
+    let cursor = at + 1;
+    while (buf[cursor] !== END) {
+      if (cursor >= buf.length) throw new Error('truncated torrent');
+      cursor = spanEnd(buf, cursor);
+    }
+    return cursor + 1;
+  }
+
+  const colon = buf.indexOf(COLON, at);
+  if (colon === -1) throw new Error('truncated torrent');
+  const length = Number(buf.toString('ascii', at, colon));
+  if (!Number.isInteger(length) || length < 0) throw new Error('not a torrent');
+  return colon + 1 + length;
+}
+
+/** Walk a bencoded dictionary, yielding each key with its value's span. */
+function* entries(buf: Buffer, from = 0): Generator<{ key: string; start: number; end: number }> {
+  if (buf[from] !== DICT) throw new Error('not a torrent');
+  let cursor = from + 1;
+  while (cursor < buf.length && buf[cursor] !== END) {
+    const keyEnd = spanEnd(buf, cursor);
+    const colon = buf.indexOf(COLON, cursor);
+    const key = buf.toString('utf8', colon + 1, keyEnd);
+    const end = spanEnd(buf, keyEnd);
+    yield { key, start: keyEnd, end };
+    cursor = end;
+  }
+}
+
+/** A bencoded string's contents, given the span of the whole value. */
+function stringAt(buf: Buffer, start: number, end: number): string {
+  const colon = buf.indexOf(COLON, start);
+  if (colon === -1 || colon >= end) return '';
+  return buf.toString('utf8', colon + 1, end);
+}
+
+export interface TorrentSummary {
+  infoHash: string;
+  name: string;
+  trackers: string[];
+}
+
+/**
+ * The infohash, name and announce list of an uploaded .torrent, or null.
+ *
+ * Null rather than a throw: this runs on a file a person picked in a file
+ * dialog, where "that is not a torrent" is an ordinary thing to have happened
+ * and deserves a 400 with a sentence, not a stack trace.
+ */
+export function readTorrent(bytes: Buffer): TorrentSummary | null {
+  if (bytes.length === 0 || bytes.length > MAX_TORRENT_BYTES) return null;
+  try {
+    let infoHash: string | null = null;
+    let name = '';
+    const trackers: string[] = [];
+
+    for (const { key, start, end } of entries(bytes)) {
+      if (key === 'info') {
+        infoHash = createHash('sha1').update(bytes.subarray(start, end)).digest('hex');
+        for (const inner of entries(bytes, start)) {
+          if (inner.key === 'name') name = stringAt(bytes, inner.start, inner.end);
+        }
+      } else if (key === 'announce') {
+        const url = stringAt(bytes, start, end);
+        if (url) trackers.push(url);
+      } else if (key === 'announce-list') {
+        // A list of lists (tiers). Only the strings inside matter here.
+        for (let cursor = start + 1; bytes[cursor] !== END && cursor < end; ) {
+          const tierEnd = spanEnd(bytes, cursor);
+          for (let inner = cursor + 1; bytes[inner] !== END && inner < tierEnd; ) {
+            const urlEnd = spanEnd(bytes, inner);
+            const url = stringAt(bytes, inner, urlEnd);
+            if (url) trackers.push(url);
+            inner = urlEnd;
+          }
+          cursor = tierEnd;
+        }
+      }
+    }
+
+    if (!infoHash) return null;
+    return { infoHash, name: name || infoHash, trackers: [...new Set(trackers)] };
+  } catch {
+    return null;
+  }
+}
+
+/** A magnet URI for a torrent we just read, carrying its own announce list. */
+export function magnetFor({ infoHash, name, trackers }: TorrentSummary): string {
+  const parts = [`magnet:?xt=urn:btih:${infoHash}`];
+  if (name) parts.push(`dn=${encodeURIComponent(name)}`);
+  // The torrent's own trackers have to survive into the magnet: a torrent that
+  // is not on the public DHT sits at zero peers forever without them, and on a
+  // private tracker the passkey that makes an announce work lives in that URL.
+  for (const tracker of trackers) parts.push(`tr=${encodeURIComponent(tracker)}`);
+  return parts.join('&');
+}


### PR DESCRIPTION
Everything that reaches a seedbox today comes from the index: you find a torrent on the site and press send. There was no way in for content the index has never seen — your own release, a magnet somebody handed you, a `.torrent` on your disk.

The machinery already existed, oddly enough: the POST under `/api/torrents/[id]/seedbox` takes an arbitrary magnet and never looks at the `[id]`. It was just unreachable from the Seedboxes page. This adds an **Add** tab and a route that is honest about what it does, rather than a torrent-scoped endpoint pressed into general service.

### Two shapes in, one path out

A magnet goes straight through. A `.torrent` is read server-side for its infohash, name and announce list and turned into a magnet — which is what every transport already speaks. So this adds a way *in* without adding a second way to *send*, and it works with the torlink already running on the boxes rather than requiring the newer one.

### Reading the .torrent needs no dependency

Bencode is four shapes and each one says where it ends, so finding a single key's value is a scan rather than a decode — and a scan is what the infohash needs anyway, because it is a SHA-1 over the **original** bytes of the `info` dictionary.

Decoding and re-encoding would change that hash the moment a client wrote a key in an order or a form we did not reproduce, and hand back a magnet for a torrent that does not exist: perfectly well-formed, and finding nobody. That is the worst available failure here, so the span has to stop exactly at the end of the dictionary — which the first test pins against a hash computed independently.

Trackers come across too, from both `announce` and every tier of `announce-list`, deduplicated. A torrent that is not on the public DHT sits at zero peers forever without them, and on a private tracker the passkey that makes an announce work at all lives inside that URL.

### Notes

- `readTorrent` returns `null` rather than throwing. This runs on a file somebody picked in a file dialog, where "that is not a torrent" is an ordinary thing to have happened and deserves a sentence, not a stack trace.
- 16 MB cap, checked before allocating: a `.torrent` is metadata, and the cap is what stops a mis-picked disk image being pulled into memory whole.
- The seedbox picker only renders when the account has more than one; otherwise the account default is used, exactly as every send did before.
- A chosen file wins over a pasted magnet, and the form says so rather than leaving you to guess when both are filled in.

### Testing

- `pnpm build` — clean; `/api/seedbox/add` present in the build output
- `npx vitest run src/lib/seedbox` — 175 passing (7 new)
- Verified against a real `.torrent` written by another client: infohash matches byte for byte, all 8 trackers recovered, garbage rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkEHoAhsoDhqVeJ1MJH9yD