### PR TITLE
deps(deps-dev): bump @types/webtorrent to 3.0.0 and adapt to its API

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@types/react-dom": "^19.2.5",
     "@types/sax": "^1.2.7",
     "@types/web-push": "^3.6.4",
-    "@types/webtorrent": "^0.110.2",
+    "@types/webtorrent": "^3.0.0",
     "@vitejs/plugin-react": "^5.1.4",
     "@vitest/coverage-v8": "^4.1.11",
     "dotenv": "^17.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
         version: 0.1.0(react@19.2.8)
       '@profullstack/stack':
         specifier: ^0.1.3
-        version: 0.1.3(next@16.3.3(@babel/core@7.29.0)(@playwright/test@1.62.1)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 0.1.3(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-dialog':
         specifier: ^1.1.23
         version: 1.1.23(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -120,7 +120,7 @@ importers:
         version: 1.8.2
       next:
         specifier: 16.3.3
-        version: 16.3.3(@babel/core@7.29.0)(@playwright/test@1.62.1)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       node-datachannel:
         specifier: ^0.33.1
         version: 0.33.1
@@ -204,8 +204,8 @@ importers:
         specifier: ^3.6.4
         version: 3.6.4
       '@types/webtorrent':
-        specifier: ^0.110.2
-        version: 0.110.2
+        specifier: ^3.0.0
+        version: 3.0.0
       '@vitejs/plugin-react':
         specifier: ^5.1.4
         version: 5.2.0(vite@7.3.1(@types/node@26.4.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12))
@@ -2093,11 +2093,8 @@ packages:
   '@types/node@26.4.0':
     resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
 
-  '@types/parse-torrent-file@4.0.6':
-    resolution: {integrity: sha512-SxqVth0Iv0WuEkqWS5MaY4S4Tlyi+QHkElQREvsUPw2xHcPgKyQ2dkJRRv5vAxmLzH+tnMdOj1Nws/wsenbzUw==}
-
-  '@types/parse-torrent@5.8.9':
-    resolution: {integrity: sha512-Ej2enMoFKlg6Vp0Kf93F3XbhlKxJicrkQ8vMAEo3GHToNukXNr3BheNc2vEv81jyzMWS4Cnta1lhuKTYNgzWUg==}
+  '@types/parse-torrent@11.0.1':
+    resolution: {integrity: sha512-rzk5O1sk/Fbu8grskEEbFb0FZyDdVIkreRs2br90Y5BNcExSAEeRJftqxvyniJcJzI1xRK4fWxS0PJfxVvVRVQ==}
 
   '@types/react-dom@19.2.5':
     resolution: {integrity: sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==}
@@ -2125,8 +2122,8 @@ packages:
   '@types/web-push@3.6.4':
     resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
 
-  '@types/webtorrent@0.110.2':
-    resolution: {integrity: sha512-K0Jvmc5TNbeKWeSj1Tt0Xp+Zvlz2aMTRk1mn0Kgnr4EdTRM3BZ6k56Rse7pAG2FojeRKh3HWFtkyOtQg7JKpqg==}
+  '@types/webtorrent@3.0.0':
+    resolution: {integrity: sha512-/ACpPNpkdGiGhHycZPZpcnDGfd8WcitdprOl8qox0A7aSwFHu2kXOMCJw/XL6jhYZlFw4ss0T5iuIJo7q7VEJw==}
 
   '@typescript-eslint/eslint-plugin@8.68.0':
     resolution: {integrity: sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==}
@@ -6199,12 +6196,12 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
 
-  '@profullstack/stack@0.1.3(next@16.3.3(@babel/core@7.29.0)(@playwright/test@1.62.1)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@profullstack/stack@0.1.3(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@profullstack/emailer': 1.0.3
       '@profullstack/referrals': 0.1.0(react@19.2.8)
     optionalDependencies:
-      next: 16.3.3(@babel/core@7.29.0)(@playwright/test@1.62.1)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
 
   '@puppeteer/browsers@3.2.1(yauzl@2.10.0)':
@@ -6952,15 +6949,10 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
-  '@types/parse-torrent-file@4.0.6':
-    dependencies:
-      '@types/node': 26.4.0
-
-  '@types/parse-torrent@5.8.9':
+  '@types/parse-torrent@11.0.1':
     dependencies:
       '@types/magnet-uri': 5.1.5
       '@types/node': 26.4.0
-      '@types/parse-torrent-file': 4.0.6
 
   '@types/react-dom@19.2.5(@types/react@19.2.18)':
     dependencies:
@@ -6989,11 +6981,11 @@ snapshots:
     dependencies:
       '@types/node': 26.4.0
 
-  '@types/webtorrent@0.110.2':
+  '@types/webtorrent@3.0.0':
     dependencies:
       '@types/bittorrent-protocol': 3.1.7
       '@types/node': 26.4.0
-      '@types/parse-torrent': 5.8.9
+      '@types/parse-torrent': 11.0.1
       '@types/simple-peer': 9.11.9
 
   '@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)':
@@ -9289,7 +9281,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@16.3.3(@babel/core@7.29.0)(@playwright/test@1.62.1)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.3.3
       '@swc/helpers': 0.5.23
@@ -9298,7 +9290,7 @@ snapshots:
       postcss: 8.5.23
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.8)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.8)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.3.3
       '@next/swc-darwin-x64': 16.3.3
@@ -10161,12 +10153,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.8):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.8):
     dependencies:
       client-only: 0.0.1
       react: 19.2.8
     optionalDependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
 
   supports-color@7.2.0:
     dependencies:

--- a/src/lib/streaming/streaming.ts
+++ b/src/lib/streaming/streaming.ts
@@ -12,6 +12,7 @@
  */
 
 import WebTorrent from 'webtorrent';
+import type { Options, Torrent, TorrentFile, TorrentOptions } from 'webtorrent';
 // Import node-datachannel polyfill to enable WebRTC in Node.js
 // This allows the server to connect to browser WebTorrent clients via WebRTC
 import nodeDataChannel from 'node-datachannel/polyfill';
@@ -349,7 +350,7 @@ interface TorrentWatchers {
  * Service for streaming media files from torrents
  */
 export class StreamingService {
-  private client: WebTorrent.Instance | null = null;
+  private client: WebTorrent | null = null;
   private maxConcurrentStreams: number;
   private streamTimeout: number;
   private torrentCleanupDelay: number;
@@ -415,7 +416,7 @@ export class StreamingService {
    * Lazily create the WebTorrent client on first use.
    * Returns the existing client if already running.
    */
-  private ensureClient(): WebTorrent.Instance {
+  private ensureClient(): WebTorrent {
     if (this.client) {
       // Cancel any pending idle shutdown — we're active again
       if (this.idleShutdownTimer) {
@@ -445,7 +446,7 @@ export class StreamingService {
       path: this.downloadPath,
       downloadLimit: 3 * 1024 * 1024,
       uploadLimit: 512 * 1024,
-    } as WebTorrent.Options);
+    } as Options);
 
     this.client.setMaxListeners(50);
 
@@ -1353,7 +1354,7 @@ export class StreamingService {
       try {
         // Pass path option to ensure downloads go to configured directory
         // Type assertion needed because WebTorrent types are incomplete
-        const torrent = client.add(enhancedMagnetUri, { path: this.downloadPath } as WebTorrent.TorrentOptions);
+        const torrent = client.add(enhancedMagnetUri, { path: this.downloadPath } as TorrentOptions);
         this.torrentAddedAt.set(torrent.infoHash, Date.now());
 
         // Use named handlers so they can be removed when torrent is destroyed
@@ -1380,7 +1381,7 @@ export class StreamingService {
             fileCount: torrent.files.length,
           });
           // Deselect all files initially - status endpoint will select specific files
-          torrent.deselect(0, torrent.pieces.length - 1, 0);
+          torrent.deselect(0, torrent.pieces.length - 1);
           // Remove ALL listeners after ready to prevent memory leaks
           removeAllListeners();
         };
@@ -1906,7 +1907,7 @@ export class StreamingService {
   /**
    * Check if an object is a valid WebTorrent torrent
    */
-  private isValidTorrent(obj: unknown): obj is WebTorrent.Torrent {
+  private isValidTorrent(obj: unknown): obj is Torrent {
     return (
       obj !== null &&
       obj !== undefined &&
@@ -2044,7 +2045,7 @@ export class StreamingService {
   /**
    * Get an existing torrent or add a new one
    */
-  private async getOrAddTorrent(magnetUri: string, infohash: string): Promise<WebTorrent.Torrent> {
+  private async getOrAddTorrent(magnetUri: string, infohash: string): Promise<Torrent> {
     logger.debug('Getting or adding torrent', { infohash });
     const startTime = Date.now();
 
@@ -2085,7 +2086,7 @@ export class StreamingService {
     // Add new torrent and wait for it to be ready
     return new Promise((resolve, reject) => {
       let timeoutId: ReturnType<typeof setTimeout> | null = null;
-      let torrent: WebTorrent.Torrent | null = null;
+      let torrent: Torrent | null = null;
       let settled = false;
       let onReadyHandler: (() => void) | null = null;
 
@@ -2175,7 +2176,7 @@ export class StreamingService {
       }, this.streamTimeout);
 
       // Pass path option to ensure downloads go to configured directory
-      torrent = client.add(enhancedMagnetUri, { path: this.downloadPath } as WebTorrent.TorrentOptions, (t) => {
+      torrent = client.add(enhancedMagnetUri, { path: this.downloadPath } as TorrentOptions, (t) => {
         this.torrentAddedAt.set(t.infoHash, Date.now());
         logger.debug('Torrent add callback fired', {
           infohash: t.infoHash,
@@ -2195,7 +2196,7 @@ export class StreamingService {
             numPeers: t.numPeers,
             elapsed: `${Date.now() - startTime}ms`
           });
-          t.deselect(0, t.pieces.length - 1, 0);
+          t.deselect(0, t.pieces.length - 1);
           resolve(t);
         };
 
@@ -2218,7 +2219,7 @@ export class StreamingService {
   /**
    * Wait for an existing torrent to become ready
    */
-  private waitForTorrentReady(torrent: WebTorrent.Torrent, infohash: string, startTime: number): Promise<WebTorrent.Torrent> {
+  private waitForTorrentReady(torrent: Torrent, infohash: string, startTime: number): Promise<Torrent> {
     return new Promise((resolve, reject) => {
       let timeoutId: ReturnType<typeof setTimeout> | null = null;
       let settled = false;
@@ -2262,7 +2263,7 @@ export class StreamingService {
           numPeers: torrent.numPeers,
           elapsed: `${Date.now() - startTime}ms`
         });
-        torrent.deselect(0, torrent.pieces.length - 1, 0);
+        torrent.deselect(0, torrent.pieces.length - 1);
         resolve(torrent);
       };
 
@@ -2311,8 +2312,8 @@ export class StreamingService {
    * @param bytesToPrioritize - Number of bytes to prioritize (default: 50MB)
    */
   private prioritizeSequentialPieces(
-    torrent: WebTorrent.Torrent,
-    file: WebTorrent.TorrentFile,
+    torrent: Torrent,
+    file: TorrentFile,
     startByte: number,
     bytesToPrioritize = 50 * 1024 * 1024
   ): void {
@@ -2361,8 +2362,8 @@ export class StreamingService {
   }
 
   private async waitForData(
-    torrent: WebTorrent.Torrent,
-    file: WebTorrent.TorrentFile,
+    torrent: Torrent,
+    file: TorrentFile,
     startByte: number
   ): Promise<void> {
     const startTime = Date.now();

--- a/src/lib/torrent/torrent.ts
+++ b/src/lib/torrent/torrent.ts
@@ -10,6 +10,7 @@
  */
 
 import WebTorrent from 'webtorrent';
+import type { Options, Torrent, TorrentOptions } from 'webtorrent';
 // Import node-datachannel polyfill to enable WebRTC in Node.js
 // This allows the server to connect to browser WebTorrent clients via WebRTC
 import nodeDataChannel from 'node-datachannel/polyfill';
@@ -208,7 +209,7 @@ const UDP_TRACKERS = [
  * Service for fetching torrent metadata without downloading content
  */
 export class TorrentService {
-  private client: WebTorrent.Instance;
+  private client: WebTorrent;
   private metadataTimeout: number;
   private downloadPath: string;
 
@@ -237,7 +238,7 @@ export class TorrentService {
       webSeeds: true,
       // Use configured download path instead of /tmp/webtorrent
       path: this.downloadPath,
-    } as WebTorrent.Options);
+    } as Options);
     
     this.metadataTimeout = timeout;
     
@@ -339,7 +340,7 @@ export class TorrentService {
     return new Promise((resolve, reject) => {
       let timeoutId: ReturnType<typeof setTimeout> | null = null;
       let progressIntervalId: ReturnType<typeof setInterval> | null = null;
-      let torrent: WebTorrent.Torrent | null = null;
+      let torrent: Torrent | null = null;
       let metadataReceived = false;
       let cleanupTorrentListeners: (() => void) | null = null;
 
@@ -385,7 +386,7 @@ export class TorrentService {
       logger.debug('Adding torrent to client', { infohash: parsed.infohash });
 
       // Helper function to extract metadata from torrent
-      const extractMetadata = (t: WebTorrent.Torrent): void => {
+      const extractMetadata = (t: Torrent): void => {
         if (metadataReceived) return; // Prevent double processing
         metadataReceived = true;
         cleanupTorrentListeners?.();
@@ -411,7 +412,7 @@ export class TorrentService {
         emitProgress('complete', 100, t.numPeers, 'Metadata received successfully');
 
         // Deselect all files to prevent downloading
-        t.deselect(0, t.pieces.length - 1, 0);
+        t.deselect(0, t.pieces.length - 1);
         logger.debug('Deselected all pieces to prevent download');
 
         // Calculate file offsets (WebTorrent doesn't expose offset directly)
@@ -476,7 +477,7 @@ export class TorrentService {
       try {
         // Pass path option to ensure downloads go to configured directory
         // Type assertion needed because WebTorrent types are incomplete
-        torrent = this.client.add(enhancedMagnetUri, { path: this.downloadPath } as WebTorrent.TorrentOptions);
+        torrent = this.client.add(enhancedMagnetUri, { path: this.downloadPath } as TorrentOptions);
         
         logger.debug('Torrent object created', {
           infohash: torrent.infoHash,


### PR DESCRIPTION
Supersedes #197.

#197 bumped `@types/webtorrent` 0.110.2 -> 3.0.0 on its own. That does not compile: v3 replaces the `export =` namespace with ES-style named exports plus a `export default class WebTorrent`, so every `WebTorrent.Foo` type reference stops resolving. `tsc --noEmit` on #197 as-is gives **38 errors** in 2 files (19x TS2702 "only refers to a type, but is being used as a namespace", plus 19 cascading TS7006 implicit-any once those annotations break).

This PR carries the same bump plus the code changes to go with it.

## Changes
- Import `Options` / `Torrent` / `TorrentFile` / `TorrentOptions` as named types from `webtorrent`.
- `WebTorrent.Instance` -> `WebTorrent`. v3 has no `Instance` export; the default class is the instance type.
- Drop the third argument from the four `deselect()` call sites.

## On the `deselect` change
This is a **no-op at runtime**, not a behavior change. webtorrent 3.0.21 declares:

```js
deselect (start, end) { this._deselect(start, end, false) }
```

Two parameters. The `0` we passed as a third argument has been silently discarded all along; the old 0.110.x types declared a three-arg signature the shipped runtime never had. v3 types just describe reality, which is what surfaced it.

## Verification
CI could not run (the org is Actions-billing-locked, so every job fails before starting). Verified locally instead, from a `--frozen-lockfile` install:

| gate | result |
| --- | --- |
| `pnpm typecheck` | pass (0 errors, was 38) |
| `pnpm lint` | pass, 0 errors / 248 warnings - identical count to master |
| `pnpm test` | 198 files, 2655 passed, 7 skipped |
| `pnpm build` | pass |

The repo pre-commit hook re-ran typecheck + tests independently and also passed.

## One thing to note
The lockfile also moves `@babel/core` 7.29.0 -> 7.29.7 (transitive, dev-only, via the styled-jsx/next peer graph). That is pnpm recomputing peer-dependency hashes when the lockfile is regenerated; it is not something I selected, and it is reproducible from a clean regeneration. A clean install on master alone produces no drift. Everything above was validated with that resolution in place.

Closes #197.