### PR TITLE
Check whether the stream came back before rebuilding it

### DIFF
--- a/src/components/live-tv/hls-player-modal.tsx
+++ b/src/components/live-tv/hls-player-modal.tsx
@@ -19,6 +19,7 @@ import { CloseIcon, RefreshIcon, TvIcon } from '@/components/ui/icons';
 import { useTvDetection } from '@/hooks/use-tv-detection';
 import { useModalOpen } from '@/hooks/use-modal-open';
 import { IptvChannelFavoriteButton } from '@/components/ui/iptv-channel-favorite-button';
+import { hasRecovered, retryDelayMs } from '@/lib/live-tv/recovery';
 
 // Type for mpegts.js player - dynamically imported
 type MpegtsPlayer = {
@@ -82,6 +83,17 @@ export function HlsPlayerModal({
   const retryCountRef = useRef(0);
   const stallCheckIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const lastPlaybackTimeRef = useRef(0);
+  /*
+   * The pending "did startLoad() actually fix it?" check, and whether another
+   * fatal error landed while it was pending.
+   *
+   * Both are refs rather than locals because the timer has to be cancellable from
+   * the teardown and from the next error. A raw setTimeout per error -- which is
+   * what this was -- accumulates: three fatal errors in a burst scheduled three
+   * independent rebuilds, each one a fresh connection on a line that counts them.
+   */
+  const recoveryCheckRef = useRef<NodeJS.Timeout | null>(null);
+  const erroredAgainRef = useRef(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -92,6 +104,12 @@ export function HlsPlayerModal({
   const MAX_RETRIES = 5;
   // Base delay for exponential backoff (ms)
   const BASE_RETRY_DELAY = 2000;
+  /*
+   * How long HLS.js is given to fix a fatal error on its own before the player is
+   * rebuilt around it. Long enough for a playlist refetch and a segment to buffer;
+   * short enough that a stream which is genuinely gone is not left frozen.
+   */
+  const RECOVERY_GRACE_MS = 5000;
 
   // The stream URL is already proxied by the channels API if needed
   // HTTP URLs are converted to /api/iptv-proxy?url=... by the server
@@ -212,10 +230,16 @@ export function HlsPlayerModal({
   const handleRefresh = useCallback((): void => {
     console.log('[HLS Player] Refreshing stream...');
 
-    // Clear any pending retry
+    // Clear any pending retry, and the pending "did it recover?" check with it --
+    // a refresh answers that question itself, and letting the check survive means
+    // it rebuilds the player the reader just rebuilt by hand.
     if (retryTimeoutRef.current) {
       clearTimeout(retryTimeoutRef.current);
       retryTimeoutRef.current = null;
+    }
+    if (recoveryCheckRef.current) {
+      clearTimeout(recoveryCheckRef.current);
+      recoveryCheckRef.current = null;
     }
 
     // Destroy existing players
@@ -247,14 +271,25 @@ export function HlsPlayerModal({
       return;
     }
 
-    const delay = BASE_RETRY_DELAY * Math.pow(2, retryCountRef.current);
+    const delay = retryDelayMs(retryCountRef.current, BASE_RETRY_DELAY);
     retryCountRef.current += 1;
 
     console.log(`[HLS Player] Scheduling retry ${retryCountRef.current}/${MAX_RETRIES} in ${delay}ms`);
     setIsRecovering(true);
     setError(`Connection lost. Retrying (${retryCountRef.current}/${MAX_RETRIES})...`);
 
+    /*
+     * Replace the pending retry rather than adding to it.
+     *
+     * This used to assign over `retryTimeoutRef.current` without clearing what
+     * was already there, so two errors close together left two live timers and
+     * the second rebuild landed on top of the first -- two players, two sockets,
+     * and a reader watching whichever won.
+     */
+    if (retryTimeoutRef.current) clearTimeout(retryTimeoutRef.current);
+
     retryTimeoutRef.current = setTimeout(() => {
+      retryTimeoutRef.current = null;
       console.log('[HLS Player] Auto-retrying stream...');
 
       // Destroy existing players
@@ -317,25 +352,92 @@ export function HlsPlayerModal({
           }
         });
 
+        /*
+         * Try the cheap recovery, then CHECK whether it worked.
+         *
+         * HLS.js can nearly always fix a fatal network error itself: startLoad()
+         * refetches the playlist, and a segment that 404'd across a discontinuity
+         * or a CDN that dropped one request simply resumes. A media error is the
+         * same shape of problem one layer down, and recoverMediaError() rebuilds
+         * the buffer without touching the connection.
+         *
+         * What both need is somebody to ask, a few seconds later, whether they
+         * worked -- and that is what was missing. The escalation was scheduled
+         * unconditionally, guarded only by "is this component still mounted and
+         * is this still the current HLS instance", which is exactly as true after
+         * a successful recovery as after a failed one. So a stream that had been
+         * playing again for four seconds was torn down and rebuilt anyway, and
+         * every rebuild is a fresh connection on a provider line that often
+         * permits precisely one.
+         *
+         * The evidence is the media clock, which is what the stall watcher below
+         * already trusts. The decision itself is in @/lib/live-tv/recovery so it
+         * can be tested -- this component's own tests are excluded from the suite
+         * over HLS.js and mpegts.js mocking.
+         */
+        const attemptRecovery = (kind: 'network' | 'media'): void => {
+          const timeAtError = video.currentTime;
+          erroredAgainRef.current = false;
+
+          if (kind === 'network') {
+            hls.startLoad();
+          } else {
+            hls.recoverMediaError();
+          }
+
+          // One pending check at a time. A burst of fatal errors used to schedule
+          // one independent rebuild each, all of which fired.
+          if (recoveryCheckRef.current) clearTimeout(recoveryCheckRef.current);
+
+          recoveryCheckRef.current = setTimeout(() => {
+            recoveryCheckRef.current = null;
+            if (!isMounted || hlsRef.current !== hls) return;
+
+            const recovered = hasRecovered({
+              timeAtError,
+              timeNow: video.currentTime,
+              paused: video.paused,
+              erroredAgain: erroredAgainRef.current,
+            });
+
+            if (recovered) {
+              // It is playing. Nothing to rebuild, and the budget goes back --
+              // the same rule `handlePlaying` applies, restated here because a
+              // recovery that never re-fired `playing` would otherwise leave the
+              // count spent.
+              console.log('[HLS Player] Recovered without a rebuild');
+              retryCountRef.current = 0;
+              setError(null);
+              setIsRecovering(false);
+              return;
+            }
+
+            console.log('[HLS Player] Recovery did not take, rebuilding');
+            scheduleRetry();
+          }, RECOVERY_GRACE_MS);
+        };
+
         hls.on(Hls.Events.ERROR, (_event, data) => {
           console.error('[HLS Player] HLS Error:', data.type, data.details, data);
           if (data.fatal && isMounted) {
+            // Seen by a pending recovery check: a stream that produced a second of
+            // video and failed again has not recovered, whatever the clock says.
+            if (recoveryCheckRef.current) erroredAgainRef.current = true;
+
             switch (data.type) {
               case Hls.ErrorTypes.NETWORK_ERROR:
                 console.error('[HLS Player] Fatal network error, attempting reload');
-                // Try to recover first
-                hls.startLoad();
-                // If still failing, schedule a full retry after a short delay
-                setTimeout(() => {
-                  if (isMounted && hlsRef.current === hls) {
-                    // Check if we're still in error state
-                    scheduleRetry();
-                  }
-                }, 5000);
+                attemptRecovery('network');
                 break;
               case Hls.ErrorTypes.MEDIA_ERROR:
+                /*
+                 * This used to call recoverMediaError() and then simply stop.
+                 * When the recovery failed there was no retry and no message --
+                 * the picture froze and nothing ever said why, which is the one
+                 * outcome worse than an error.
+                 */
                 console.error('[HLS Player] Fatal media error, attempting recovery');
-                hls.recoverMediaError();
+                attemptRecovery('media');
                 break;
               default:
                 console.error('[HLS Player] Fatal error, scheduling retry');
@@ -517,6 +619,14 @@ export function HlsPlayerModal({
       if (retryTimeoutRef.current) {
         clearTimeout(retryTimeoutRef.current);
         retryTimeoutRef.current = null;
+      }
+
+      // The recovery check outlives the player it was asking about unless it is
+      // cancelled here: closing the modal mid-check would otherwise fire a rebuild
+      // into a torn-down page and open a connection nobody is watching.
+      if (recoveryCheckRef.current) {
+        clearTimeout(recoveryCheckRef.current);
+        recoveryCheckRef.current = null;
       }
 
       if (hlsRef.current) {

--- a/src/lib/live-tv/recovery.test.ts
+++ b/src/lib/live-tv/recovery.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { hasRecovered, retryDelayMs } from './recovery';
+
+/**
+ * The decision that used to be made by not making it.
+ *
+ * A fatal HLS network error scheduled a full player rebuild five seconds later
+ * whatever happened in between, because the guard only asked whether the
+ * component was still mounted -- true after a successful recovery too. So a
+ * stream that `startLoad()` had already fixed was torn down and reconnected
+ * anyway, and every rebuild is a fresh connection on a line that often permits
+ * one.
+ */
+describe('deciding whether a stream came back', () => {
+  it('a clock that moved is a stream that recovered', () => {
+    expect(hasRecovered({ timeAtError: 12, timeNow: 16.5, paused: false })).toBe(true);
+  });
+
+  it('a clock that has not moved is not, however healthy everything else looks', () => {
+    // The whole test. This is the case the old guard could not see.
+    expect(hasRecovered({ timeAtError: 12, timeNow: 12, paused: false })).toBe(false);
+  });
+
+  it('a second failure overrides a clock that moved', () => {
+    /*
+     * A stream can produce a second of video and fail again. Reading that as a
+     * recovery leaves a player that never rebuilds and never reports, which from
+     * the sofa is indistinguishable from a frozen picture.
+     */
+    expect(
+      hasRecovered({ timeAtError: 12, timeNow: 13, paused: false, erroredAgain: true })
+    ).toBe(false);
+  });
+
+  it('a paused video is recovered, because it is not a failure to recover from', () => {
+    /*
+     * The reader stopped it. Rebuilding underneath them would restart the stream
+     * they deliberately paused -- and on a one-connection line, take the slot to
+     * do it.
+     */
+    expect(hasRecovered({ timeAtError: 12, timeNow: 12, paused: true })).toBe(true);
+  });
+
+  it('a clock that went backwards still counts as movement', () => {
+    /*
+     * A live stream whose buffer was rebuilt can legitimately resume at a lower
+     * currentTime. Requiring a forward step would call that a failure and rebuild
+     * a stream that is playing.
+     */
+    expect(hasRecovered({ timeAtError: 30, timeNow: 4, paused: false })).toBe(true);
+  });
+});
+
+describe('spacing the attempts out', () => {
+  it('doubles from the base, so a busy line is not hammered', () => {
+    expect(retryDelayMs(0, 2000)).toBe(2000);
+    expect(retryDelayMs(1, 2000)).toBe(4000);
+    expect(retryDelayMs(2, 2000)).toBe(8000);
+    expect(retryDelayMs(4, 2000)).toBe(32000);
+  });
+
+  it('treats a negative attempt as the first one rather than shrinking the wait', () => {
+    // A guard rather than a feature: a fractional or negative delay would mean
+    // reconnecting instantly, which is the one thing the backoff exists to stop.
+    expect(retryDelayMs(-3, 2000)).toBe(2000);
+  });
+});

--- a/src/lib/live-tv/recovery.ts
+++ b/src/lib/live-tv/recovery.ts
@@ -1,0 +1,75 @@
+/**
+ * When a stream that just failed has actually come back.
+ *
+ * HLS.js answers a fatal network error with `startLoad()`, which reloads the
+ * playlist and very often simply works -- a segment 404'd during a discontinuity,
+ * the provider hiccupped, the CDN dropped one request. The player then has to
+ * decide, a few seconds later, whether that worked or whether the whole thing
+ * needs rebuilding.
+ *
+ * It used to decide by not deciding. The escalation was scheduled unconditionally
+ * and its guard only asked whether the component was still mounted and the HLS
+ * instance had not been replaced -- both of which are true after a SUCCESSFUL
+ * recovery. So every fatal network error tore the player down and rebuilt it five
+ * seconds later even when the picture had been back for four of them, and each
+ * rebuild is a fresh connection on a provider line that often permits exactly one.
+ *
+ * The honest question is whether the media clock moved, which is the same evidence
+ * the stall watcher already trusts and the only thing that distinguishes a stream
+ * that recovered from one that is still broken. It lives here rather than inside
+ * the component because the component's own tests are excluded from the suite over
+ * HLS.js and mpegts.js mocking, and a decision nothing can test is a decision that
+ * drifts.
+ */
+
+/** What the media element looked like at two points in time. */
+export interface RecoveryCheck {
+  /** `video.currentTime` when the error arrived. */
+  timeAtError: number;
+  /** `video.currentTime` now, after the grace period. */
+  timeNow: number;
+  /** A paused video is not a failed one -- the reader stopped it. */
+  paused: boolean;
+  /** Set when another fatal error arrived during the grace period. */
+  erroredAgain?: boolean;
+}
+
+/**
+ * Did playback resume?
+ *
+ * Deliberately strict about what counts as evidence:
+ *
+ *   - A clock that has not moved is not a recovery, however healthy everything
+ *     else looks. This is the whole test.
+ *   - A second fatal error during the grace period overrides a moved clock. A
+ *     stream can produce a second of video and fail again, and treating that as
+ *     recovered leaves a player that never rebuilds and never reports.
+ *   - Paused counts as recovered, because it is not a failure to recover FROM.
+ *     Rebuilding the player under a reader who deliberately paused would restart
+ *     the stream they stopped, and on a one-connection line that is the worst
+ *     available way to respond to a pause.
+ *   - Time going BACKWARDS counts as movement. A live stream whose buffer was
+ *     rebuilt can legitimately resume at a lower currentTime, and requiring a
+ *     forward step would call that a failure and rebuild a working stream.
+ */
+export function hasRecovered({
+  timeAtError,
+  timeNow,
+  paused,
+  erroredAgain = false,
+}: RecoveryCheck): boolean {
+  if (erroredAgain) return false;
+  if (paused) return true;
+  return timeNow !== timeAtError;
+}
+
+/**
+ * How long to wait before the next attempt.
+ *
+ * Doubling, so a line that is genuinely busy is not hammered: a provider that
+ * counts concurrent connections sees one attempt, then one four seconds later,
+ * rather than five inside a second. `attempt` is zero-based.
+ */
+export function retryDelayMs(attempt: number, baseMs: number): number {
+  return baseMs * 2 ** Math.max(0, attempt);
+}


### PR DESCRIPTION
The headline bug from the two sibling apps ([tipoffwatch#20](https://github.com/profullstack/tipoffwatch.com/pull/20), [genrewatch#5](https://github.com/profullstack/genrewatch.com/pull/5)) **is not here**, and it is worth saying why: this player inspects no status codes, so it cannot give up on a transient one, and it persists no liveness, so it cannot write a busy line down as a dead channel. That is exactly why it was the reference implementation both were compared against.

What it does have is the same family of defect one layer over: **a transient failure causing a destructive action nobody checked was necessary.**

## The main one

A fatal HLS network error called `startLoad()` and then scheduled a full player rebuild five seconds later:

```js
hls.startLoad();
setTimeout(() => {
  if (isMounted && hlsRef.current === hls) {
    // Check if we're still in error state   <- it never did
    scheduleRetry();
  }
}, 5000);
```

The guard only asks whether the component is still mounted and this is still the current instance. Both are as true after a **successful** recovery as after a failed one — and `startLoad()` usually succeeds: a segment that 404s across a discontinuity, a CDN that drops one request. So a stream that had been playing again for four seconds was torn down and reconnected anyway, and every rebuild is a fresh connection on a provider line that often permits exactly one.

Now the recovery gets the same five seconds and is then **asked whether it worked**, on the evidence the stall watcher already trusts: did the media clock move. Recovered → nothing is rebuilt and the retry budget goes back. Not recovered → the rebuild proceeds exactly as before.

The decision lives in `src/lib/live-tv/recovery.ts` rather than inside the component, because `hls-player-modal.test.tsx` is in vitest's exclude list (`Tests that fail in CI due to browser API mocking issues`) — a decision nothing can test is a decision that drifts.

## Two more of the same shape

- **Overlapping rebuilds.** The escalation used a raw `setTimeout` per error, so a burst of three fatal errors scheduled three independent rebuilds, all of which fired. And `scheduleRetry` assigned over `retryTimeoutRef.current` without clearing it, so two errors close together left two live timers and the second rebuild landed on top of the first — two players, two sockets, and a reader watching whichever won. Both are single-flight now, and both are cancelled on teardown and on a manual refresh.

- **A media error that failed silently.** A fatal `MEDIA_ERROR` called `recoverMediaError()` and then stopped. When that failed there was no retry and no message: the picture froze and nothing said why, which is the one outcome worse than an error. It now takes the same checked path.

## Tests

New `src/lib/live-tv/recovery.test.ts` — 7 tests, and it actually runs. Covers a clock that moved, a clock that did not (the case the old guard could not see), a second failure overriding a moved clock, a paused video counting as recovered rather than being restarted underneath the reader, a clock that legitimately went backwards after a buffer rebuild, and the backoff ladder.

`pnpm test`: **2662 pass across 199 files**. `typecheck`, `lint` (0 errors) and `next build` all clean. The one `react-hooks/refs` warning inside the touched file is pre-existing and on a line this branch does not modify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QajXU2fsQhkjB9ViHrG3Dp