### PR TITLE
Release 0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "media-streamer",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump for the retry-discipline fix in #199.

The last tag is `v0.3.0` against a `package.json` that had already moved to 0.3.3, so this also puts the two back in step. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QajXU2fsQhkjB9ViHrG3Dp