### PR TITLE
feat(spotify): pair a Spotify account and listen via librespot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -200,6 +200,19 @@ ALPACA_API_SECRET=your-alpaca-api-secret
 #   rotate works.
 PROXY_URL=
 
+# Spotify (/spotify)
+# Each user pairs their own Spotify Premium account with a code at
+# spotify.com/pair. The server runs one librespot process per paired user,
+# which appears as a Spotify Connect device; casting to it produces an HLS
+# stream that plays in the browser. Credentials persist encrypted in
+# bt_spotify_sessions (ENCRYPTION_KEY) and are restored on restart.
+#
+# LIBRESPOT_PATH — librespot binary; defaults to `librespot` on PATH (the
+#   Dockerfile builds it). FFMPEG_PATH likewise defaults to `ffmpeg`.
+# SPOTIFY_DEVICE_NAME — name shown in the Spotify device picker.
+LIBRESPOT_PATH=
+SPOTIFY_DEVICE_NAME=BitTorrented
+
 # YouTube / Google OAuth
 # Required for /youtube search, subscribed-channel browsing, and subscription
 # subscribe/unsubscribe actions. Each user connects their own Google account

--- a/.env.example
+++ b/.env.example
@@ -207,8 +207,8 @@ PROXY_URL=
 # stream that plays in the browser. Credentials persist encrypted in
 # bt_spotify_sessions (ENCRYPTION_KEY) and are restored on restart.
 #
-# LIBRESPOT_PATH — librespot binary; defaults to `librespot` on PATH (the
-#   Dockerfile builds it). FFMPEG_PATH likewise defaults to `ffmpeg`.
+# LIBRESPOT_PATH — librespot binary; defaults to `librespot` on PATH
+#   (scripts/setup-server.sh installs it on the droplet, the Dockerfile builds it). FFMPEG_PATH likewise defaults to `ffmpeg`.
 # SPOTIFY_DEVICE_NAME — name shown in the Spotify device picker.
 LIBRESPOT_PATH=
 SPOTIFY_DEVICE_NAME=BitTorrented

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@
 # No prebuilt binaries exist, and device pairing (--enable-device-auth) is not
 # in the 0.8.0 tag, so this builds a pinned commit from git. rustls keeps the
 # musl build free of OpenSSL; the pipe/subprocess audio backends need no
-# system audio libraries.
+# system audio libraries. The droplet deploy does not use this image; it
+# installs the same binary from the `librespot-<rev>` release asset (see
+# scripts/setup-server.sh), which is produced by this stage.
 FROM rust:1-alpine AS librespot
 RUN apk add --no-cache musl-dev
 ARG LIBRESPOT_REV=a1b66d3c8a14e55a9572a9e17467150dca618c9a

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
 # BitTorrented.com Dockerfile
 # Multi-stage build for production deployment
 
+# Stage 0: librespot (Spotify Connect receiver for /spotify)
+# No prebuilt binaries exist, and device pairing (--enable-device-auth) is not
+# in the 0.8.0 tag, so this builds a pinned commit from git. rustls keeps the
+# musl build free of OpenSSL; the pipe/subprocess audio backends need no
+# system audio libraries.
+FROM rust:1-alpine AS librespot
+RUN apk add --no-cache musl-dev
+ARG LIBRESPOT_REV=a1b66d3c8a14e55a9572a9e17467150dca618c9a
+RUN cargo install --git https://github.com/librespot-org/librespot --rev ${LIBRESPOT_REV} \
+    --no-default-features --features rustls-tls-webpki-roots --root /out librespot
+
 # Stage 1: Dependencies
 FROM node:26-alpine AS deps
 RUN corepack enable && corepack prepare pnpm@latest --activate
@@ -35,6 +46,9 @@ WORKDIR /app
 
 # Install FFmpeg for video/audio transcoding, and build tools for reliq/torge
 RUN apk add --no-cache ffmpeg git curl make gcc musl-dev bash jq
+
+# librespot: Spotify Connect receiver spawned per user by src/lib/spotify
+COPY --from=librespot /out/bin/librespot /usr/local/bin/librespot
 
 # Install reliq (HTML parsing library - must be installed before torge)
 RUN git clone https://github.com/TUVIMEN/reliq.git /tmp/reliq && \

--- a/scripts/setup-server.sh
+++ b/scripts/setup-server.sh
@@ -108,6 +108,33 @@ else
     echo "All essential packages already installed"
 fi
 
+# librespot: the Spotify Connect receiver that src/lib/spotify spawns per
+# paired user (/spotify). No upstream binaries exist and the pairing flow is
+# not in a tagged release, so a static musl build from the Dockerfile's
+# `librespot` stage is hosted as a release asset on this repo. Pinned by
+# commit and checksum; re-run after bumping LIBRESPOT_REV in the Dockerfile.
+echo "=== Checking librespot ==="
+LIBRESPOT_REV="a1b66d3c8a14e55a9572a9e17467150dca618c9a"
+LIBRESPOT_SHA256="c99aa8466cf5f76f84e43489d59f5db63081c44de250d504bac84f9c47cb4c54"
+LIBRESPOT_URL="https://github.com/profullstack/media-streamer/releases/download/librespot-${LIBRESPOT_REV:0:7}/librespot-x86_64-linux-musl"
+LIBRESPOT_STAMP="/usr/local/share/librespot.rev"
+if [ "$(uname -m)" != "x86_64" ]; then
+    echo "librespot: no prebuilt binary for $(uname -m); /spotify will report it missing"
+elif [ -x /usr/local/bin/librespot ] && [ "$(cat "$LIBRESPOT_STAMP" 2>/dev/null)" = "$LIBRESPOT_REV" ]; then
+    echo "librespot already at ${LIBRESPOT_REV:0:7}"
+else
+    LIBRESPOT_TMP="$(mktemp)"
+    if curl -fsSL --retry 3 -o "$LIBRESPOT_TMP" "$LIBRESPOT_URL" \
+        && echo "${LIBRESPOT_SHA256}  ${LIBRESPOT_TMP}" | sha256sum -c --quiet; then
+        sudo install -m 0755 "$LIBRESPOT_TMP" /usr/local/bin/librespot
+        echo "$LIBRESPOT_REV" | sudo tee "$LIBRESPOT_STAMP" > /dev/null
+        echo "✓ librespot installed: $(/usr/local/bin/librespot --version 2>/dev/null | head -1)"
+    else
+        echo "✗ librespot download or checksum failed; /spotify will report it missing"
+    fi
+    rm -f "$LIBRESPOT_TMP"
+fi
+
 # Chromium runtime libraries for headless Puppeteer (used by news article
 # extractor and SiriusXM device-grant minter). Puppeteer ships its own
 # Chromium binary; this just makes sure the system shared libs it needs
@@ -1068,6 +1095,7 @@ echo "Installed versions:"
 echo "  Node.js: $(node --version 2>/dev/null || echo 'not found')"
 echo "  pnpm: $(pnpm --version 2>/dev/null || echo 'not found')"
 echo "  ffmpeg: $(ffmpeg -version 2>/dev/null | head -1 || echo 'not found')"
+echo "  librespot: $(librespot --version 2>/dev/null | head -1 || echo 'not found')"
 echo "  nginx: $(nginx -v 2>&1 | head -1 || echo 'not found')"
 echo ""
 echo "Configuration:"

--- a/src/app/api/spotify/connect/route.ts
+++ b/src/app/api/spotify/connect/route.ts
@@ -1,0 +1,36 @@
+/**
+ * POST /api/spotify/connect
+ *
+ * Starts Spotify device pairing for the current user and returns the code to
+ * enter at spotify.com/pair. Credentials are persisted the moment librespot
+ * writes them, from inside the process manager, so the pairing survives the
+ * user closing the tab.
+ */
+
+import { NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth';
+import { getSpotifyPlayerManager, saveSpotifyCredentials } from '@/lib/spotify';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(): Promise<Response> {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  try {
+    const status = await getSpotifyPlayerManager().startPairing(user.id, {
+      onCredentials: async (credentialsJson) => {
+        await saveSpotifyCredentials({ userId: user.id, credentialsJson });
+      },
+    });
+    if (status.state === 'error') {
+      return NextResponse.json({ error: status.error ?? 'Could not start pairing' }, { status: 502 });
+    }
+    return NextResponse.json(status, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    console.error('[spotify/connect]', error);
+    return NextResponse.json({ error: 'Failed to start Spotify pairing' }, { status: 500 });
+  }
+}

--- a/src/app/api/spotify/disconnect/route.ts
+++ b/src/app/api/spotify/disconnect/route.ts
@@ -1,0 +1,29 @@
+/**
+ * POST /api/spotify/disconnect
+ *
+ * Stops the user's librespot process, wipes its state directory (cached
+ * credentials, playlist, segments) and deletes the stored credentials. The
+ * device disappears from their Spotify apps within a few seconds.
+ */
+
+import { NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth';
+import { deleteSpotifyCredentials, getSpotifyPlayerManager } from '@/lib/spotify';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(): Promise<Response> {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  try {
+    getSpotifyPlayerManager().stop(user.id, { purge: true });
+    await deleteSpotifyCredentials(user.id);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('[spotify/disconnect]', error);
+    return NextResponse.json({ error: 'Failed to disconnect Spotify' }, { status: 500 });
+  }
+}

--- a/src/app/api/spotify/status/route.test.ts
+++ b/src/app/api/spotify/status/route.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The status route is also the lazy starter: after a deploy nothing runs
+ * until a paired user loads the page, and that first request must bring the
+ * device back without asking them to pair again.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetCurrentUser = vi.fn();
+vi.mock('@/lib/auth', () => ({ getCurrentUser: () => mockGetCurrentUser() }));
+
+const mockGetStatus = vi.fn();
+const mockEnsureRunning = vi.fn();
+const mockGetCredentials = vi.fn();
+vi.mock('@/lib/spotify', () => ({
+  getSpotifyPlayerManager: () => ({ getStatus: mockGetStatus, ensureRunning: mockEnsureRunning }),
+  getSpotifyCredentials: (userId: string) => mockGetCredentials(userId),
+}));
+
+const stopped = {
+  state: 'stopped',
+  deviceName: 'BitTorrented',
+  pairing: null,
+  nowPlaying: null,
+  hasStream: false,
+  error: null,
+};
+
+describe('GET /api/spotify/status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue({ id: 'user-1', email: 'u@example.com' });
+    mockGetStatus.mockReturnValue(stopped);
+    mockGetCredentials.mockResolvedValue(null);
+  });
+
+  it('requires a session', async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+    const { GET } = await import('./route');
+    expect((await GET()).status).toBe(401);
+  });
+
+  it('reports not connected when nothing is stored and nothing runs', async () => {
+    const { GET } = await import('./route');
+    const body = await (await GET()).json();
+    expect(body.connected).toBe(false);
+    expect(body.state).toBe('stopped');
+    expect(mockEnsureRunning).not.toHaveBeenCalled();
+  });
+
+  it('starts librespot from stored credentials when the process is not running', async () => {
+    mockGetCredentials.mockResolvedValue({ userId: 'user-1', username: 'anthony', credentialsJson: '{"u":1}' });
+    mockEnsureRunning.mockReturnValue({ ...stopped, state: 'connecting' });
+    const { GET } = await import('./route');
+    const body = await (await GET()).json();
+    expect(mockEnsureRunning).toHaveBeenCalledWith('user-1', '{"u":1}');
+    expect(body.connected).toBe(true);
+    expect(body.username).toBe('anthony');
+    expect(body.state).toBe('connecting');
+    expect(body.streamUrl).toBe('/api/spotify/stream/index.m3u8');
+  });
+
+  it('does not touch the database while pairing is in progress', async () => {
+    mockGetStatus.mockReturnValue({ ...stopped, state: 'pairing', pairing: { url: 'u', code: 'C' } });
+    const { GET } = await import('./route');
+    const body = await (await GET()).json();
+    expect(mockGetCredentials).not.toHaveBeenCalled();
+    expect(body.state).toBe('pairing');
+    expect(body.pairing).toEqual({ url: 'u', code: 'C' });
+  });
+});

--- a/src/app/api/spotify/status/route.ts
+++ b/src/app/api/spotify/status/route.ts
@@ -1,0 +1,51 @@
+/**
+ * GET /api/spotify/status
+ *
+ * Reports the current user's Spotify device: whether an account is paired,
+ * what the librespot process is doing, and what is playing. If credentials
+ * exist but the process is not running (first request after a deploy), this
+ * is also where it gets started, so a restart needs no user action.
+ */
+
+import { NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth';
+import { getSpotifyCredentials, getSpotifyPlayerManager } from '@/lib/spotify';
+
+export const dynamic = 'force-dynamic';
+
+export const STREAM_URL = '/api/spotify/stream/index.m3u8';
+
+export async function GET(): Promise<Response> {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  try {
+    const manager = getSpotifyPlayerManager();
+    let status = manager.getStatus(user.id);
+    let connected = status.state !== 'stopped' && status.state !== 'error';
+    let username: string | null = null;
+
+    if (status.state !== 'pairing') {
+      const creds = await getSpotifyCredentials(user.id);
+      if (creds) {
+        connected = true;
+        username = creds.username;
+        if (status.state === 'stopped') {
+          status = manager.ensureRunning(user.id, creds.credentialsJson);
+        }
+      } else if (status.state !== 'error') {
+        connected = false;
+      }
+    }
+
+    return NextResponse.json(
+      { connected, username, streamUrl: STREAM_URL, ...status },
+      { headers: { 'Cache-Control': 'no-store' } }
+    );
+  } catch (error) {
+    console.error('[spotify/status]', error);
+    return NextResponse.json({ error: 'Failed to load Spotify status' }, { status: 500 });
+  }
+}

--- a/src/app/api/spotify/stream/[file]/route.test.ts
+++ b/src/app/api/spotify/stream/[file]/route.test.ts
@@ -1,0 +1,79 @@
+/**
+ * The stream route serves files from the user's own HLS directory and nothing
+ * else. The gate is the filename shape, so these tests pin the shape and the
+ * auth check rather than the file contents.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetCurrentUser = vi.fn();
+vi.mock('@/lib/auth', () => ({ getCurrentUser: () => mockGetCurrentUser() }));
+
+const tempRoot = join(process.cwd(), '.tmp-spotify-stream-test');
+vi.mock('@/lib/config/temp-dir', () => ({ getTempDir: () => tempRoot }));
+
+function call(file: string): Promise<Response> {
+  return import('./route').then(({ GET }) =>
+    GET(new Request(`http://localhost/api/spotify/stream/${file}`), {
+      params: Promise.resolve({ file }),
+    })
+  );
+}
+
+describe('GET /api/spotify/stream/[file]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue({ id: 'user-1', email: 'u@example.com' });
+    const hls = join(tempRoot, 'spotify', 'user-1', 'hls');
+    mkdirSync(hls, { recursive: true });
+    writeFileSync(join(hls, 'index.m3u8'), '#EXTM3U\n#EXTINF:2.0,\nseg_00001.ts\n');
+    writeFileSync(join(hls, 'seg_00001.ts'), Buffer.from([0x47, 0x00, 0x11]));
+    mkdirSync(join(tempRoot, 'spotify', 'user-1', 'cache'), { recursive: true });
+    writeFileSync(join(tempRoot, 'spotify', 'user-1', 'cache', 'credentials.json'), '{"secret":1}');
+  });
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('requires a session', async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+    const res = await call('index.m3u8');
+    expect(res.status).toBe(401);
+  });
+
+  it('serves the playlist uncached with the HLS content type', async () => {
+    const res = await call('index.m3u8');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/vnd.apple.mpegurl');
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    expect(await res.text()).toContain('seg_00001.ts');
+  });
+
+  it('serves a segment as MPEG-TS', async () => {
+    const res = await call('seg_00001.ts');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('video/mp2t');
+    expect((await res.arrayBuffer()).byteLength).toBe(3);
+  });
+
+  it('404s before anything is playing', async () => {
+    const res = await call('seg_00009.ts');
+    expect(res.status).toBe(404);
+  });
+
+  it('never serves a name outside the two ffmpeg shapes', async () => {
+    for (const bad of ['..%2Fcache%2Fcredentials.json', 'credentials.json', 'index.m3u8.tmp']) {
+      const res = await call(decodeURIComponent(bad));
+      expect(res.status).toBe(404);
+    }
+  });
+
+  it('serves only the current user directory', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: 'user-2', email: 'v@example.com' });
+    const res = await call('index.m3u8');
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/spotify/stream/[file]/route.ts
+++ b/src/app/api/spotify/stream/[file]/route.ts
@@ -1,0 +1,53 @@
+/**
+ * GET /api/spotify/stream/{index.m3u8 | seg_00042.ts}
+ *
+ * Serves the current user's own HLS output. The playlist ffmpeg writes uses
+ * relative segment names, so the manifest and its segments must share a URL
+ * prefix; a path segment (not a query param) is what makes hls.js resolve
+ * them against this route. Only the two filename shapes ffmpeg produces are
+ * served, which is also what keeps the path from ever leaving the HLS dir.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth';
+import { getSpotifyPlayerManager } from '@/lib/spotify';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ file: string }> }
+): Promise<Response> {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  const { file } = await context.params;
+  const path = getSpotifyPlayerManager().hlsPath(user.id, file);
+  if (!path) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  let body: Buffer;
+  try {
+    body = await readFile(path);
+  } catch {
+    return NextResponse.json(
+      { error: file.endsWith('.m3u8') ? 'Nothing is playing yet' : 'Not found' },
+      { status: 404, headers: { 'Cache-Control': 'no-store' } }
+    );
+  }
+
+  const isPlaylist = file.endsWith('.m3u8');
+  return new Response(new Uint8Array(body), {
+    status: 200,
+    headers: {
+      'Content-Type': isPlaylist ? 'application/vnd.apple.mpegurl' : 'video/mp2t',
+      // The playlist changes every segment; a segment never changes.
+      'Cache-Control': isPlaylist ? 'no-store' : 'private, max-age=60',
+      'Content-Length': String(body.byteLength),
+    },
+  });
+}

--- a/src/app/spotify/page.tsx
+++ b/src/app/spotify/page.tsx
@@ -1,0 +1,26 @@
+/**
+ * Spotify Page (Server Component)
+ *
+ * Server-side auth check - redirects to login if not authenticated.
+ */
+
+import { redirect } from 'next/navigation';
+import { getCurrentUser } from '@/lib/auth';
+import { SpotifyContent } from './spotify-content';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Spotify | BitTorrented',
+  description: 'Cast your Spotify to BitTorrented and listen in the browser',
+};
+
+export default async function SpotifyPage(): Promise<React.ReactElement> {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    redirect('/login?redirect=/spotify');
+  }
+
+  return <SpotifyContent />;
+}

--- a/src/app/spotify/spotify-content.tsx
+++ b/src/app/spotify/spotify-content.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+/**
+ * Spotify page body.
+ *
+ * Three views: pair an account, wait for a cast, and listen. The stream is a
+ * live HLS playlist written by the user's own librespot process, so the player
+ * is the same `attachSource` ladder the radio modal uses, attached on a click
+ * (autoplay needs the gesture anyway) and torn down on Stop.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { attachSource } from '@profullstack/player';
+import { LoadingSpinner } from '@/components/ui/icons';
+import { useSpotifyStatus, type SpotifyStatus } from '@/hooks/use-spotify-status';
+
+const buttonPrimary =
+  'inline-flex items-center justify-center gap-2 rounded-lg bg-accent-primary px-4 py-2 text-sm font-medium text-white hover:bg-accent-primary/90 disabled:opacity-60';
+const buttonSecondary =
+  'inline-flex items-center justify-center gap-2 rounded-lg border border-border-default bg-bg-secondary px-4 py-2 text-sm text-text-primary hover:bg-bg-tertiary disabled:opacity-60';
+
+function stateLabel(status: SpotifyStatus): string {
+  switch (status.state) {
+    case 'pairing':
+      return 'Waiting for you to enter the code';
+    case 'connecting':
+      return 'Connecting to Spotify';
+    case 'online':
+      return 'Ready. Cast to it from any Spotify app.';
+    case 'playing':
+      return 'Playing';
+    case 'paused':
+      return 'Paused';
+    case 'error':
+      return 'Not running';
+    default:
+      return 'Not connected';
+  }
+}
+
+export function SpotifyContent(): React.ReactElement {
+  const { status, isLoading, error, refetch } = useSpotifyStatus();
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const connect = useCallback(async () => {
+    setBusy(true);
+    setActionError(null);
+    try {
+      const res = await fetch('/api/spotify/connect', { method: 'POST', credentials: 'include' });
+      const data = (await res.json()) as { error?: string };
+      if (!res.ok) throw new Error(data.error ?? `status ${res.status}`);
+      await refetch();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [refetch]);
+
+  const disconnect = useCallback(async () => {
+    if (!window.confirm('Disconnect Spotify? You will need to pair again to listen.')) return;
+    setBusy(true);
+    setActionError(null);
+    try {
+      const res = await fetch('/api/spotify/disconnect', { method: 'POST', credentials: 'include' });
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      await refetch();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [refetch]);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-4 sm:p-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold text-text-primary">Spotify</h1>
+        <p className="text-sm text-text-secondary">
+          Pair your Spotify Premium account and BitTorrented shows up as a speaker in your Spotify
+          apps. Cast to it and the music plays here, in the browser.
+        </p>
+      </header>
+
+      {error ? <p className="text-sm text-red-500">Could not load status: {error}</p> : null}
+      {actionError ? <p className="text-sm text-red-500">{actionError}</p> : null}
+
+      {isLoading && !status ? (
+        <div className="inline-flex items-center gap-2 text-sm text-text-muted">
+          <LoadingSpinner size={16} /> Loading
+        </div>
+      ) : null}
+
+      {status && !status.connected && status.state !== 'pairing' ? (
+        <section className="space-y-4 rounded-lg border border-border-default bg-bg-secondary p-4">
+          <p className="text-sm text-text-secondary">
+            Pairing opens a one-time code on Spotify&apos;s site. Enter it from your phone or any
+            browser where you are signed in. Spotify Premium is required.
+          </p>
+          {status.state === 'error' && status.error ? (
+            <p className="text-sm text-red-500">{status.error}</p>
+          ) : null}
+          <button type="button" className={buttonPrimary} onClick={() => void connect()} disabled={busy}>
+            {busy ? <LoadingSpinner size={16} /> : null}
+            Pair Spotify
+          </button>
+        </section>
+      ) : null}
+
+      {status?.state === 'pairing' ? <PairingCard status={status} /> : null}
+
+      {status?.connected && status.state !== 'pairing' ? (
+        <>
+          <section className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border-default bg-bg-secondary px-4 py-3 text-sm">
+            <div className="flex items-center gap-3">
+              <span
+                className={`h-2 w-2 rounded-full ${
+                  status.state === 'error' ? 'bg-red-500' : status.state === 'connecting' ? 'bg-amber-400' : 'bg-emerald-500'
+                }`}
+                aria-hidden
+              />
+              <span className="text-text-primary">{status.username ?? 'Spotify connected'}</span>
+              <span className="text-text-muted">{stateLabel(status)}</span>
+            </div>
+            <button type="button" className="text-text-muted hover:text-text-primary" onClick={() => void disconnect()} disabled={busy}>
+              Disconnect
+            </button>
+          </section>
+
+          {status.state === 'error' && status.error ? (
+            <p className="text-sm text-red-500">{status.error}</p>
+          ) : null}
+
+          <section className="space-y-2 rounded-lg border border-border-default bg-bg-secondary p-4 text-sm text-text-secondary">
+            <p className="font-medium text-text-primary">How to play</p>
+            <ol className="list-decimal space-y-1 pl-5">
+              <li>Open Spotify on your phone or desktop and start anything.</li>
+              <li>
+                Tap the devices icon and choose <span className="text-text-primary">{status.deviceName}</span>.
+              </li>
+              <li>Press Listen below.</li>
+            </ol>
+          </section>
+
+          <NowPlaying status={status} />
+          <Player status={status} />
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function PairingCard({ status }: { status: SpotifyStatus }): React.ReactElement {
+  const pairing = status.pairing;
+  return (
+    <section className="space-y-4 rounded-lg border border-border-default bg-bg-secondary p-4">
+      <p className="text-sm text-text-secondary">
+        Enter this code at{' '}
+        <a
+          href={pairing?.url ?? 'https://spotify.com/pair'}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="text-accent-primary underline"
+        >
+          spotify.com/pair
+        </a>{' '}
+        while signed in to the account you want to use.
+      </p>
+      {pairing ? (
+        <p className="rounded-lg border border-border-default bg-bg-primary px-3 py-2 text-center font-mono text-3xl tracking-[0.4em] text-text-primary">
+          {pairing.code}
+        </p>
+      ) : (
+        <div className="inline-flex items-center gap-2 text-sm text-text-muted">
+          <LoadingSpinner size={16} /> Getting a code from Spotify
+        </div>
+      )}
+      <div className="inline-flex items-center gap-2 text-sm text-text-muted">
+        <LoadingSpinner size={16} /> Waiting for Spotify to confirm
+      </div>
+    </section>
+  );
+}
+
+function formatMs(ms: number | null): string {
+  if (ms === null || !Number.isFinite(ms)) return '';
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function NowPlaying({ status }: { status: SpotifyStatus }): React.ReactElement | null {
+  const np = status.nowPlaying;
+  if (!np || !np.name) return null;
+  return (
+    <section className="rounded-lg border border-border-default bg-bg-secondary p-4">
+      <p className="text-xs uppercase tracking-wide text-text-muted">
+        {status.state === 'paused' ? 'Paused' : 'Now playing'}
+      </p>
+      <p className="mt-1 text-lg font-medium text-text-primary">{np.name}</p>
+      <p className="text-sm text-text-secondary">
+        {np.artists.join(', ')}
+        {np.album ? ` · ${np.album}` : ''}
+      </p>
+      {np.durationMs ? (
+        <p className="mt-1 text-xs text-text-muted">
+          {formatMs(np.positionMs)} / {formatMs(np.durationMs)}
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function Player({ status }: { status: SpotifyStatus }): React.ReactElement {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [listening, setListening] = useState(false);
+  const [playerError, setPlayerError] = useState<string | null>(null);
+  const canListen = status.hasStream && (status.state === 'playing' || status.state === 'paused');
+
+  useEffect(() => {
+    if (!listening || !audioRef.current) return;
+    const audio = audioRef.current;
+    let cancelled = false;
+    let attached: { destroy: () => void } | null = null;
+
+    // attachSource sets the element's src only after its engine chunk loads,
+    // so play() has to wait for the returned promise rather than run in this
+    // same commit.
+    void attachSource(audio, {
+      src: status.streamUrl,
+      kind: 'hls',
+      live: true,
+      onError: (message) => {
+        if (!cancelled) setPlayerError(message);
+      },
+    })
+      .then((result) => {
+        if (cancelled) {
+          result.destroy();
+          return;
+        }
+        attached = result;
+        audio.play().catch((err) => {
+          console.error('[Spotify] Play error:', err);
+          if (!cancelled) setPlayerError('Failed to play audio');
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setPlayerError('Stream error. Cast something to the device and try again.');
+      });
+
+    return () => {
+      cancelled = true;
+      attached?.destroy();
+      audio.pause();
+      audio.removeAttribute('src');
+      audio.load();
+    };
+  }, [listening, status.streamUrl]);
+
+  return (
+    <section className="space-y-3 rounded-lg border border-border-default bg-bg-secondary p-4">
+      <div className="flex flex-wrap items-center gap-3">
+        {listening ? (
+          <button type="button" className={buttonSecondary} onClick={() => setListening(false)}>
+            Stop
+          </button>
+        ) : (
+          <button
+            type="button"
+            className={buttonPrimary}
+            onClick={() => {
+              setPlayerError(null);
+              setListening(true);
+            }}
+            disabled={!canListen}
+            title={canListen ? undefined : 'Cast something to the device first'}
+          >
+            Listen
+          </button>
+        )}
+        {!canListen && !listening ? (
+          <span className="text-sm text-text-muted">Nothing is being cast yet.</span>
+        ) : null}
+      </div>
+      {playerError ? <p className="text-sm text-red-500">{playerError}</p> : null}
+      <audio ref={audioRef} controls className={listening ? 'w-full' : 'hidden'} />
+    </section>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -32,6 +32,7 @@ import {
   SearchPlusIcon,
   NewsIcon,
   RadioIcon,
+  SpotifyIcon,
   RssIcon,
   HeartIcon,
   MovieIcon,
@@ -68,6 +69,7 @@ const mainNavItems: NavItem[] = [
   { href: '/youtube', label: 'YouTube', icon: VideoIcon, requiresAuth: true },
   { href: '/live-tv', label: 'Live TV', icon: TvIcon, requiresAuth: true },
   { href: '/radio', label: 'Live Radio', icon: RadioIcon, requiresAuth: true },
+  { href: '/spotify', label: 'Spotify', icon: SpotifyIcon, requiresAuth: true },
   { href: '/watch-party', label: 'Watch Party', icon: PartyIcon },
 ];
 

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -1471,3 +1471,25 @@ export function FinanceIcon({ className, size = 20 }: IconProps): React.ReactEle
     </svg>
   );
 }
+
+export function SpotifyIcon({ className, size = 20 }: IconProps): React.ReactElement {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={cn('', className)}
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="M7 9.5c3.5-1 7-.7 10 1" />
+      <path d="M7.5 12.5c3-.8 5.8-.5 8.5 1" />
+      <path d="M8 15.5c2.3-.6 4.5-.4 6.5.8" />
+    </svg>
+  );
+}

--- a/src/hooks/use-spotify-status.ts
+++ b/src/hooks/use-spotify-status.ts
@@ -1,0 +1,75 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { SpotifyPlayerStatus } from '@/lib/spotify/librespot';
+
+export interface SpotifyStatus extends SpotifyPlayerStatus {
+  connected: boolean;
+  username: string | null;
+  streamUrl: string;
+}
+
+export interface UseSpotifyStatusResult {
+  status: SpotifyStatus | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+/** Poll faster while something is in flight, slower once the device is idle. */
+function pollDelay(status: SpotifyStatus | null): number {
+  if (!status) return 3_000;
+  switch (status.state) {
+    case 'pairing':
+    case 'connecting':
+      return 1_500;
+    case 'playing':
+      return 3_000;
+    default:
+      return 5_000;
+  }
+}
+
+export function useSpotifyStatus(): UseSpotifyStatusResult {
+  const [status, setStatus] = useState<SpotifyStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /** Fetch once; resolves with the status so the poller can pick its next delay. */
+  const fetchStatus = useCallback(async (): Promise<SpotifyStatus | null> => {
+    setError(null);
+    try {
+      const res = await fetch('/api/spotify/status', { credentials: 'include', cache: 'no-store' });
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const data = (await res.json()) as SpotifyStatus;
+      setStatus(data);
+      return data;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const refetch = useCallback(async (): Promise<void> => {
+    await fetchStatus();
+  }, [fetchStatus]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async (): Promise<void> => {
+      const latest = await fetchStatus();
+      if (cancelled) return;
+      timer.current = setTimeout(() => void tick(), pollDelay(latest));
+    };
+    void tick();
+    return () => {
+      cancelled = true;
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [fetchStatus]);
+
+  return { status, isLoading, error, refetch };
+}

--- a/src/lib/spotify/credentials.ts
+++ b/src/lib/spotify/credentials.ts
@@ -1,0 +1,92 @@
+/**
+ * Per-user Spotify credentials repository.
+ *
+ * Stores the `credentials.json` librespot writes after device pairing. It is
+ * a reusable login for the user's whole account, so unlike the SiriusXM table
+ * it is encrypted at rest with the platform AES-256-GCM helper. Uses the
+ * service-role client and scopes by userId; RLS still protects browser access.
+ */
+
+import { createServerClient } from '@/lib/supabase';
+import { decryptSecret, encryptSecret } from '@/lib/seedbox/crypto';
+
+const TABLE = 'bt_spotify_sessions';
+
+export interface SpotifyCredentials {
+  userId: string;
+  username: string | null;
+  credentialsJson: string;
+  updatedAt: string;
+}
+
+export interface SaveSpotifyCredentialsInput {
+  userId: string;
+  credentialsJson: string;
+}
+
+interface DbRow {
+  user_id: string;
+  username: string | null;
+  credentials_enc: string;
+  updated_at: string;
+}
+
+const COLUMNS = 'user_id, username, credentials_enc, updated_at';
+
+function rowToCredentials(row: DbRow): SpotifyCredentials {
+  return {
+    userId: row.user_id,
+    username: row.username,
+    credentialsJson: decryptSecret(row.credentials_enc),
+    updatedAt: row.updated_at,
+  };
+}
+
+/** The display name inside librespot's credentials file, if present. */
+export function usernameFromCredentials(credentialsJson: string): string | null {
+  try {
+    const parsed = JSON.parse(credentialsJson) as { username?: unknown };
+    return typeof parsed.username === 'string' && parsed.username ? parsed.username : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function getSpotifyCredentials(userId: string): Promise<SpotifyCredentials | null> {
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select(COLUMNS)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) throw new Error(`getSpotifyCredentials: ${error.message}`);
+  if (!data) return null;
+  return rowToCredentials(data as DbRow);
+}
+
+export async function saveSpotifyCredentials(
+  input: SaveSpotifyCredentialsInput
+): Promise<SpotifyCredentials> {
+  const supabase = createServerClient();
+  const payload = {
+    user_id: input.userId,
+    username: usernameFromCredentials(input.credentialsJson),
+    credentials_enc: encryptSecret(input.credentialsJson),
+  };
+
+  const { data, error } = await supabase
+    .from(TABLE)
+    .upsert(payload, { onConflict: 'user_id' })
+    .select(COLUMNS)
+    .single();
+
+  if (error) throw new Error(`saveSpotifyCredentials: ${error.message}`);
+  return rowToCredentials(data as DbRow);
+}
+
+export async function deleteSpotifyCredentials(userId: string): Promise<void> {
+  const supabase = createServerClient();
+  const { error } = await supabase.from(TABLE).delete().eq('user_id', userId);
+  if (error) throw new Error(`deleteSpotifyCredentials: ${error.message}`);
+}

--- a/src/lib/spotify/index.ts
+++ b/src/lib/spotify/index.ts
@@ -1,0 +1,2 @@
+export * from './librespot';
+export * from './credentials';

--- a/src/lib/spotify/librespot.integration.test.ts
+++ b/src/lib/spotify/librespot.integration.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Drives the real librespot binary through the manager. Skipped unless
+ * LIBRESPOT_PATH points at one, so CI never needs it; run it locally after
+ * bumping the pinned commit, because the argument set is only ever validated
+ * by the binary itself (an unknown flag is a silent exit, not a type error).
+ *
+ *   LIBRESPOT_PATH=/path/to/librespot pnpm exec vitest run src/lib/spotify/librespot.integration
+ */
+
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const binary = process.env.LIBRESPOT_PATH;
+const tempRoot = mkdtempSync(join(tmpdir(), 'spotify-integration-'));
+
+vi.mock('@/lib/config/temp-dir', () => ({ getTempDir: () => tempRoot }));
+
+describe.skipIf(!binary || !existsSync(binary))('librespot pairing (real binary)', () => {
+  let manager: import('./librespot').SpotifyPlayerManager;
+
+  beforeAll(async () => {
+    const { SpotifyPlayerManager } = await import('./librespot');
+    manager = new SpotifyPlayerManager();
+  });
+
+  afterAll(() => {
+    manager?.stopAll();
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('accepts our argument set and prints a pairing code', async () => {
+    const status = await manager.startPairing('integration-user', { deviceName: 'BitTorrented Test' });
+    expect(status.error).toBeNull();
+    expect(status.state).toBe('pairing');
+    expect(status.pairing?.code).toMatch(/^[A-Z0-9-]{4,}$/);
+    expect(status.pairing?.url).toContain('spotify.com/pair');
+    expect(existsSync(join(tempRoot, 'spotify', 'integration-user', 'onevent.cjs'))).toBe(true);
+  }, 20_000);
+
+  it('reports stopped after stop()', () => {
+    manager.stop('integration-user', { purge: true });
+    expect(manager.getStatus('integration-user').state).toBe('stopped');
+    expect(existsSync(join(tempRoot, 'spotify', 'integration-user'))).toBe(false);
+  });
+});

--- a/src/lib/spotify/librespot.test.ts
+++ b/src/lib/spotify/librespot.test.ts
@@ -1,0 +1,180 @@
+/**
+ * The process manager's pure parts: the ffmpeg command librespot will split
+ * with shell-words, the pairing-line parser, the event hook, and the
+ * filename gate on the stream route. If the hook's merge breaks, the page
+ * still plays audio but the now-playing card goes blank, which nobody would
+ * report as a bug; if the filename gate loosens, the route serves files
+ * outside the HLS directory.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ONEVENT_SCRIPT,
+  buildFfmpegCommand,
+  buildLibrespotArgs,
+  isSafeHlsFile,
+  parsePairingLine,
+  playbackStateFromEvent,
+  shellQuote,
+} from './librespot';
+
+describe('shellQuote', () => {
+  it('leaves plain tokens alone', () => {
+    expect(shellQuote('ffmpeg')).toBe('ffmpeg');
+    expect(shellQuote('/home/a/tmp/seg_%05d.ts')).toBe('/home/a/tmp/seg_%05d.ts');
+  });
+
+  it('single-quotes anything with spaces or quotes', () => {
+    expect(shellQuote('/home/my user/x')).toBe("'/home/my user/x'");
+    expect(shellQuote("it's")).toBe("'it'\\''s'");
+  });
+});
+
+describe('buildFfmpegCommand', () => {
+  it('reads S16LE stereo PCM from stdin and writes a live rolling playlist', () => {
+    const cmd = buildFfmpegCommand('/state/hls');
+    expect(cmd.startsWith('ffmpeg ')).toBe(true);
+    expect(cmd).toContain('-f s16le -ar 44100 -ac 2 -i pipe:0');
+    expect(cmd).toContain('-c:a aac');
+    expect(cmd).toContain('append_list');
+    expect(cmd).toContain('omit_endlist');
+    expect(cmd).toContain('temp_file');
+    expect(cmd).toContain('/state/hls/seg_%05d.ts');
+    expect(cmd.endsWith('/state/hls/index.m3u8')).toBe(true);
+  });
+
+  it('quotes a directory with spaces so shell-words keeps it as one argument', () => {
+    const cmd = buildFfmpegCommand('/my state/hls');
+    expect(cmd).toContain("'/my state/hls/index.m3u8'");
+  });
+});
+
+describe('buildLibrespotArgs', () => {
+  const base = {
+    deviceName: 'BitTorrented',
+    cacheDir: '/state/cache',
+    ffmpegCommand: 'ffmpeg -i pipe:0 out.m3u8',
+    oneventCommand: 'node /state/onevent.cjs',
+  };
+
+  it('uses the subprocess backend with fixed volume and no discovery', () => {
+    const args = buildLibrespotArgs({ ...base, deviceAuth: false });
+    const pairs = new Map<string, string>();
+    for (let i = 0; i < args.length; i += 1) {
+      if (args[i].startsWith('--') && i + 1 < args.length && !args[i + 1].startsWith('--')) {
+        pairs.set(args[i], args[i + 1]);
+      }
+    }
+    expect(pairs.get('--backend')).toBe('subprocess');
+    expect(pairs.get('--device')).toBe(base.ffmpegCommand);
+    expect(pairs.get('--volume-ctrl')).toBe('fixed');
+    expect(pairs.get('--format')).toBe('S16');
+    expect(pairs.get('--onevent')).toBe(base.oneventCommand);
+    expect(args).toContain('--disable-discovery');
+    expect(args).not.toContain('--enable-device-auth');
+  });
+
+  it('adds device auth only when pairing', () => {
+    expect(buildLibrespotArgs({ ...base, deviceAuth: true })).toContain('--enable-device-auth');
+  });
+});
+
+describe('parsePairingLine', () => {
+  it('reads the URL and the code from librespot stdout', () => {
+    expect(parsePairingLine('Browse to: https://spotify.com/pair?code=SAN88F')).toEqual({
+      url: 'https://spotify.com/pair?code=SAN88F',
+    });
+    expect(parsePairingLine('If prompted, enter code: SAN88F')).toEqual({ code: 'SAN88F' });
+  });
+
+  it('ignores everything else', () => {
+    expect(parsePairingLine('[INFO librespot] librespot 0.8.0')).toBeNull();
+    expect(parsePairingLine('')).toBeNull();
+  });
+});
+
+describe('playbackStateFromEvent', () => {
+  it('maps hook events onto the coarse states the page shows', () => {
+    expect(playbackStateFromEvent(undefined)).toBe('connecting');
+    expect(playbackStateFromEvent('session_disconnected')).toBe('connecting');
+    expect(playbackStateFromEvent('session_connected')).toBe('online');
+    expect(playbackStateFromEvent('stopped')).toBe('online');
+    expect(playbackStateFromEvent('track_changed')).toBe('playing');
+    expect(playbackStateFromEvent('playing')).toBe('playing');
+    expect(playbackStateFromEvent('paused')).toBe('paused');
+  });
+});
+
+describe('isSafeHlsFile', () => {
+  it('accepts only what ffmpeg writes', () => {
+    expect(isSafeHlsFile('index.m3u8')).toBe(true);
+    expect(isSafeHlsFile('seg_00042.ts')).toBe(true);
+  });
+
+  it('rejects traversal and anything else', () => {
+    for (const bad of ['../credentials.json', 'index.m3u8.tmp', 'seg_1.ts', 'cache/credentials.json', '', 'seg_00042.ts/..']) {
+      expect(isSafeHlsFile(bad)).toBe(false);
+    }
+  });
+});
+
+describe('onevent hook', () => {
+  let dir: string;
+  let script: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'spotify-onevent-'));
+    script = join(dir, 'onevent.cjs');
+    file = join(dir, 'events.json');
+    writeFileSync(script, ONEVENT_SCRIPT);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function fire(env: Record<string, string>): Record<string, unknown> {
+    execFileSync(process.execPath, [script], {
+      env: { ...process.env, SPOTIFY_EVENT_FILE: file, ...env },
+    });
+    return JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>;
+  }
+
+  it('keeps track metadata across the playback events that carry none', () => {
+    fire({
+      PLAYER_EVENT: 'track_changed',
+      TRACK_ID: 'abc',
+      URI: 'spotify:track:abc',
+      NAME: 'Song',
+      ARTISTS: 'One\nTwo',
+      ALBUM: 'Album',
+      DURATION_MS: '180000',
+    });
+    const after = fire({ PLAYER_EVENT: 'playing', TRACK_ID: 'abc', POSITION_MS: '5000' });
+    expect(after.event).toBe('playing');
+    expect(after.name).toBe('Song');
+    expect(after.artists).toEqual(['One', 'Two']);
+    expect(after.album).toBe('Album');
+    expect(after.durationMs).toBe(180000);
+    expect(after.positionMs).toBe(5000);
+  });
+
+  it('replaces metadata on the next track', () => {
+    fire({ PLAYER_EVENT: 'track_changed', TRACK_ID: 'a', NAME: 'First', ARTISTS: 'X', DURATION_MS: '1000' });
+    const next = fire({ PLAYER_EVENT: 'track_changed', TRACK_ID: 'b', NAME: 'Second', ARTISTS: 'Y' });
+    expect(next.name).toBe('Second');
+    expect(next.artists).toEqual(['Y']);
+    expect(next.durationMs).toBeNull();
+    expect(next.positionMs).toBe(0);
+  });
+
+  it('does nothing without a target file', () => {
+    execFileSync(process.execPath, [script], { env: { ...process.env, SPOTIFY_EVENT_FILE: '', PLAYER_EVENT: 'playing' } });
+    expect(() => readFileSync(file)).toThrow();
+  });
+});

--- a/src/lib/spotify/librespot.ts
+++ b/src/lib/spotify/librespot.ts
@@ -1,0 +1,603 @@
+/**
+ * librespot process manager.
+ *
+ * Spotify has no stream URL to proxy. The web player decrypts audio inside the
+ * browser's DRM module, so the only way to get sound out of an account on a
+ * server is the desktop client protocol, which the librespot project
+ * implements. This module runs one `librespot` process per connected user:
+ *
+ *   librespot --backend subprocess --device "ffmpeg ... index.m3u8"
+ *
+ * librespot appears in the user's Spotify apps as a Connect device. When they
+ * cast to it, librespot spawns the ffmpeg command, pipes 44.1 kHz stereo PCM
+ * into its stdin, and ffmpeg writes a rolling HLS playlist into the user's
+ * state directory. Pausing closes the sink, which ends that ffmpeg; resuming
+ * starts a fresh one that appends to the same playlist. The Next process never
+ * touches the audio path and never has to babysit ffmpeg.
+ *
+ * Login is Spotify's device-pairing flow: librespot prints a URL and a short
+ * code, the user enters the code at spotify.com/pair from any device, and
+ * librespot writes `credentials.json` into its cache directory. That file is
+ * what we persist (encrypted) so restarts need no user action. Spotify removed
+ * username/password login in 2024, so there is no other headless path.
+ *
+ * Track metadata comes from librespot's `--onevent` hook rather than the Web
+ * API: the hook receives NAME/ARTISTS/ALBUM/URI as environment variables and
+ * merges them into an events file the status route reads. No developer app,
+ * no OAuth token, no quota.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getTempDir } from '@/lib/config/temp-dir';
+
+export type SpotifyPlayerState =
+  | 'stopped'
+  | 'pairing'
+  | 'connecting'
+  | 'online'
+  | 'playing'
+  | 'paused'
+  | 'error';
+
+export interface SpotifyPairing {
+  url: string;
+  code: string;
+}
+
+export interface SpotifyNowPlaying {
+  event: string;
+  trackId: string | null;
+  uri: string | null;
+  name: string | null;
+  artists: string[];
+  album: string | null;
+  durationMs: number | null;
+  positionMs: number | null;
+  updatedAt: string;
+}
+
+export interface SpotifyPlayerStatus {
+  state: SpotifyPlayerState;
+  deviceName: string;
+  pairing: SpotifyPairing | null;
+  nowPlaying: SpotifyNowPlaying | null;
+  /** True once ffmpeg has written a playlist, i.e. there is something to play. */
+  hasStream: boolean;
+  error: string | null;
+}
+
+export interface LibrespotArgsOptions {
+  deviceName: string;
+  cacheDir: string;
+  ffmpegCommand: string;
+  oneventCommand: string;
+  deviceAuth: boolean;
+  bitrate?: 96 | 160 | 320;
+}
+
+/** Filenames ffmpeg writes into the HLS directory. Anything else is not served. */
+const HLS_FILE_RE = /^(index\.m3u8|seg_\d{5}\.ts)$/;
+
+export function isSafeHlsFile(name: string): boolean {
+  return HLS_FILE_RE.test(name);
+}
+
+/** Default Connect device name. Each user only ever sees their own device. */
+export function defaultDeviceName(): string {
+  return process.env.SPOTIFY_DEVICE_NAME?.trim() || 'BitTorrented';
+}
+
+/**
+ * Quote one argument for librespot's `--device` command string. librespot
+ * splits it with the `shell_words` crate (POSIX shell rules, no shell), so
+ * single quotes with the usual '\'' escape are exact.
+ */
+export function shellQuote(arg: string): string {
+  if (/^[A-Za-z0-9_./:%=+-]+$/.test(arg)) return arg;
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * The ffmpeg invocation librespot runs each time the sink opens. Reads raw
+ * S16LE PCM on stdin and keeps a short rolling HLS window.
+ *
+ * `append_list` continues the segment numbering across sink restarts so a
+ * paused-then-resumed stream does not reset the media sequence under hls.js;
+ * `omit_endlist` keeps the playlist live when ffmpeg exits on pause;
+ * `temp_file` makes each playlist write atomic so a reader never sees a
+ * half-written manifest.
+ */
+export function buildFfmpegCommand(hlsDir: string, ffmpegBinary = 'ffmpeg'): string {
+  const args = [
+    ffmpegBinary,
+    '-hide_banner',
+    '-loglevel', 'error',
+    '-nostdin',
+    '-f', 's16le',
+    '-ar', '44100',
+    '-ac', '2',
+    '-i', 'pipe:0',
+    '-c:a', 'aac',
+    '-b:a', '160k',
+    '-f', 'hls',
+    '-hls_time', '2',
+    '-hls_list_size', '8',
+    '-hls_flags', 'delete_segments+append_list+omit_endlist+temp_file',
+    '-hls_segment_filename', join(hlsDir, 'seg_%05d.ts'),
+    join(hlsDir, 'index.m3u8'),
+  ];
+  return args.map(shellQuote).join(' ');
+}
+
+export function buildLibrespotArgs(opts: LibrespotArgsOptions): string[] {
+  const args = [
+    '--name', opts.deviceName,
+    '--device-type', 'speaker',
+    '--backend', 'subprocess',
+    '--device', opts.ffmpegCommand,
+    '--format', 'S16',
+    '--bitrate', String(opts.bitrate ?? 320),
+    // The user's phone volume slider must not scale the stream we serve.
+    '--volume-ctrl', 'fixed',
+    '--initial-volume', '100',
+    '--cache', opts.cacheDir,
+    '--disable-audio-cache',
+    // No zeroconf: the device is registered through the account, not the LAN.
+    '--disable-discovery',
+    '--onevent', opts.oneventCommand,
+  ];
+  if (opts.deviceAuth) args.push('--enable-device-auth');
+  return args;
+}
+
+/**
+ * Parse one line of librespot's stdout during device pairing. It prints:
+ *   Browse to: https://spotify.com/pair?code=ABC123
+ *   If prompted, enter code: ABC123
+ */
+export function parsePairingLine(line: string): Partial<SpotifyPairing> | null {
+  const url = /^\s*Browse to:\s*(\S+)/i.exec(line);
+  if (url) return { url: url[1] };
+  const code = /enter code:\s*([A-Z0-9-]+)/i.exec(line);
+  if (code) return { code: code[1] };
+  return null;
+}
+
+/**
+ * The `--onevent` hook, written into the state directory at spawn time so the
+ * runtime image needs nothing beyond node. It merges each event into one JSON
+ * file: `track_changed` carries the metadata, the playback events carry only
+ * the track id and position, so the file is the union of the latest of each.
+ * Written via rename so a status read never sees a partial file.
+ */
+export const ONEVENT_SCRIPT = `'use strict';
+const fs = require('fs');
+const file = process.env.SPOTIFY_EVENT_FILE;
+if (!file) process.exit(0);
+const e = process.env;
+const ev = e.PLAYER_EVENT || '';
+let prev = {};
+try { prev = JSON.parse(fs.readFileSync(file, 'utf8')); } catch {}
+const next = Object.assign({}, prev, { event: ev, updatedAt: new Date().toISOString() });
+if (ev === 'track_changed') {
+  next.trackId = e.TRACK_ID || null;
+  next.uri = e.URI || null;
+  next.name = e.NAME || null;
+  next.artists = String(e.ARTISTS || '').split('\\n').map((s) => s.trim()).filter(Boolean);
+  next.album = e.ALBUM || null;
+  next.durationMs = e.DURATION_MS ? Number(e.DURATION_MS) : null;
+  next.positionMs = 0;
+} else if (ev === 'playing' || ev === 'paused' || ev === 'seeked' || ev === 'position_correction') {
+  if (e.POSITION_MS) next.positionMs = Number(e.POSITION_MS);
+  if (e.TRACK_ID) next.trackId = e.TRACK_ID;
+} else if (ev === 'stopped' || ev === 'session_disconnected') {
+  next.positionMs = null;
+}
+const tmp = file + '.tmp';
+fs.writeFileSync(tmp, JSON.stringify(next));
+fs.renameSync(tmp, file);
+`;
+
+const PLAYING_EVENTS = new Set([
+  'playing',
+  'track_changed',
+  'loading',
+  'preloading',
+  'seeked',
+  'position_correction',
+  'play_request_id_changed',
+]);
+
+/** Map the last hook event onto a coarse player state. */
+export function playbackStateFromEvent(event: string | null | undefined): SpotifyPlayerState {
+  if (!event) return 'connecting';
+  if (event === 'session_disconnected') return 'connecting';
+  if (event === 'paused') return 'paused';
+  if (PLAYING_EVENTS.has(event)) return 'playing';
+  return 'online';
+}
+
+/** How long to wait for the pairing code to appear on stdout. */
+const PAIRING_CODE_TIMEOUT_MS = 10_000;
+const CREDENTIALS_POLL_MS = 1_000;
+const MAX_RESTARTS = 5;
+const STDERR_TAIL_LINES = 20;
+
+export interface StartOptions {
+  deviceName?: string;
+  /** Called once librespot writes credentials.json during pairing. */
+  onCredentials?: (credentialsJson: string) => Promise<void>;
+}
+
+export function spotifyStateDir(userId: string): string {
+  return join(getTempDir(), 'spotify', userId);
+}
+
+class LibrespotPlayer {
+  private child: ChildProcess | null = null;
+  private pairing: SpotifyPairing | null = null;
+  private deviceAuth = false;
+  private stopping = false;
+  private credentialsCaptured = false;
+  private credentialsPoll: NodeJS.Timeout | null = null;
+  private restartTimer: NodeJS.Timeout | null = null;
+  private restarts = 0;
+  private lastError: string | null = null;
+  private stderrTail: string[] = [];
+  private pairingWaiters: Array<() => void> = [];
+  private onCredentials: StartOptions['onCredentials'];
+  readonly deviceName: string;
+
+  constructor(
+    readonly userId: string,
+    deviceName: string,
+  ) {
+    this.deviceName = deviceName;
+  }
+
+  get stateDir(): string {
+    return spotifyStateDir(this.userId);
+  }
+  get cacheDir(): string {
+    return join(this.stateDir, 'cache');
+  }
+  get hlsDir(): string {
+    return join(this.stateDir, 'hls');
+  }
+  get eventFile(): string {
+    return join(this.stateDir, 'events.json');
+  }
+  get credentialsFile(): string {
+    return join(this.cacheDir, 'credentials.json');
+  }
+
+  get running(): boolean {
+    return this.child !== null && this.child.exitCode === null && !this.child.killed;
+  }
+
+  /** Fresh directories for a run. The HLS dir is swept so stale segments never mix. */
+  private prepareDirs(): void {
+    mkdirSync(this.cacheDir, { recursive: true });
+    rmSync(this.hlsDir, { recursive: true, force: true });
+    mkdirSync(this.hlsDir, { recursive: true });
+    rmSync(this.eventFile, { force: true });
+    writeFileSync(join(this.stateDir, 'onevent.cjs'), ONEVENT_SCRIPT, { mode: 0o644 });
+  }
+
+  /** Start a device-pairing run. Any cached credentials are discarded first. */
+  startPairing(opts: StartOptions): void {
+    this.stopProcess();
+    rmSync(this.credentialsFile, { force: true });
+    this.credentialsCaptured = false;
+    this.onCredentials = opts.onCredentials;
+    this.deviceAuth = true;
+    this.restarts = 0;
+    this.spawnProcess();
+  }
+
+  /** Start (or keep) a run from persisted credentials. */
+  ensureRunning(credentialsJson: string): void {
+    if (this.running) return;
+    if (this.restartTimer) return; // a restart is already scheduled
+    this.deviceAuth = false;
+    this.credentialsCaptured = true;
+    this.prepareDirs();
+    writeFileSync(this.credentialsFile, credentialsJson, { mode: 0o600 });
+    this.spawnProcess({ dirsReady: true });
+  }
+
+  private spawnProcess(options: { dirsReady?: boolean } = {}): void {
+    if (!options.dirsReady) this.prepareDirs();
+    this.stopping = false;
+    this.pairing = null;
+    this.lastError = null;
+    this.stderrTail = [];
+
+    const binary = process.env.LIBRESPOT_PATH?.trim() || 'librespot';
+    const args = buildLibrespotArgs({
+      deviceName: this.deviceName,
+      cacheDir: this.cacheDir,
+      ffmpegCommand: buildFfmpegCommand(this.hlsDir, process.env.FFMPEG_PATH?.trim() || 'ffmpeg'),
+      oneventCommand: `${shellQuote(process.execPath)} ${shellQuote(join(this.stateDir, 'onevent.cjs'))}`,
+      deviceAuth: this.deviceAuth,
+    });
+
+    let child: ChildProcess;
+    try {
+      child = spawn(binary, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, SPOTIFY_EVENT_FILE: this.eventFile },
+      });
+    } catch (err) {
+      this.lastError = `Could not start librespot: ${err instanceof Error ? err.message : String(err)}`;
+      return;
+    }
+    this.child = child;
+
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      this.lastError =
+        err.code === 'ENOENT'
+          ? `librespot binary not found (${binary}). Set LIBRESPOT_PATH.`
+          : `librespot failed: ${err.message}`;
+      this.child = null;
+      this.resolvePairingWaiters();
+    });
+
+    let stdoutBuf = '';
+    child.stdout?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
+      stdoutBuf += chunk;
+      const lines = stdoutBuf.split('\n');
+      stdoutBuf = lines.pop() ?? '';
+      for (const line of lines) this.handleStdoutLine(line);
+    });
+
+    let stderrBuf = '';
+    child.stderr?.setEncoding('utf8');
+    child.stderr?.on('data', (chunk: string) => {
+      stderrBuf += chunk;
+      const lines = stderrBuf.split('\n');
+      stderrBuf = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        this.stderrTail.push(line);
+        if (this.stderrTail.length > STDERR_TAIL_LINES) this.stderrTail.shift();
+      }
+    });
+
+    child.on('exit', (code, signal) => {
+      this.child = null;
+      this.stopCredentialsPoll();
+      this.resolvePairingWaiters();
+      if (this.stopping) return;
+
+      const detail = this.stderrTail.filter((l) => /ERROR|WARN/.test(l)).slice(-3).join(' | ');
+      if (this.deviceAuth && !this.credentialsCaptured) {
+        this.lastError = detail
+          ? `Pairing did not complete: ${detail}`
+          : 'Pairing did not complete. Start again to get a new code.';
+        this.pairing = null;
+        return;
+      }
+
+      if (this.restarts >= MAX_RESTARTS) {
+        this.lastError = `librespot exited (${signal ?? code}) and stopped restarting${detail ? `: ${detail}` : ''}`;
+        return;
+      }
+      const delay = 3_000 * 2 ** this.restarts;
+      this.restarts += 1;
+      this.lastError = null;
+      this.restartTimer = setTimeout(() => {
+        this.restartTimer = null;
+        if (!this.stopping) {
+          this.deviceAuth = false;
+          this.spawnProcess();
+        }
+      }, delay);
+      this.restartTimer.unref?.();
+    });
+
+    if (this.deviceAuth) this.startCredentialsPoll();
+  }
+
+  private handleStdoutLine(line: string): void {
+    const parsed = parsePairingLine(line);
+    if (!parsed) return;
+    this.pairing = { url: '', code: '', ...(this.pairing ?? {}), ...parsed };
+    if (this.pairing.url && this.pairing.code) this.resolvePairingWaiters();
+  }
+
+  private startCredentialsPoll(): void {
+    this.stopCredentialsPoll();
+    this.credentialsPoll = setInterval(() => {
+      if (this.credentialsCaptured || !existsSync(this.credentialsFile)) return;
+      let json: string;
+      try {
+        json = readFileSync(this.credentialsFile, 'utf8');
+        JSON.parse(json);
+      } catch {
+        return; // still being written
+      }
+      this.credentialsCaptured = true;
+      this.pairing = null;
+      this.stopCredentialsPoll();
+      // A successful pairing should reconnect quietly from now on.
+      this.restarts = 0;
+      void this.onCredentials?.(json).catch((err) => {
+        this.lastError = `Could not save Spotify credentials: ${err instanceof Error ? err.message : String(err)}`;
+      });
+    }, CREDENTIALS_POLL_MS);
+    this.credentialsPoll.unref?.();
+  }
+
+  private stopCredentialsPoll(): void {
+    if (this.credentialsPoll) clearInterval(this.credentialsPoll);
+    this.credentialsPoll = null;
+  }
+
+  private resolvePairingWaiters(): void {
+    const waiters = this.pairingWaiters;
+    this.pairingWaiters = [];
+    for (const w of waiters) w();
+  }
+
+  /** Resolve once a full pairing code is known, the process dies, or the timeout passes. */
+  waitForPairingCode(timeoutMs = PAIRING_CODE_TIMEOUT_MS): Promise<void> {
+    if ((this.pairing?.url && this.pairing.code) || !this.running) return Promise.resolve();
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        this.pairingWaiters = this.pairingWaiters.filter((w) => w !== done);
+        resolve();
+      }, timeoutMs);
+      timer.unref?.();
+      const done = (): void => {
+        clearTimeout(timer);
+        resolve();
+      };
+      this.pairingWaiters.push(done);
+    });
+  }
+
+  private stopProcess(): void {
+    this.stopping = true;
+    if (this.restartTimer) clearTimeout(this.restartTimer);
+    this.restartTimer = null;
+    this.stopCredentialsPoll();
+    const child = this.child;
+    this.child = null;
+    if (child && child.exitCode === null) {
+      child.kill('SIGTERM');
+      const force = setTimeout(() => {
+        if (child.exitCode === null) child.kill('SIGKILL');
+      }, 3_000);
+      force.unref?.();
+    }
+    this.pairing = null;
+    this.resolvePairingWaiters();
+  }
+
+  stop(options: { purge?: boolean } = {}): void {
+    this.stopProcess();
+    this.lastError = null;
+    if (options.purge) rmSync(this.stateDir, { recursive: true, force: true });
+  }
+
+  readNowPlaying(): SpotifyNowPlaying | null {
+    try {
+      const raw = JSON.parse(readFileSync(this.eventFile, 'utf8')) as Partial<SpotifyNowPlaying>;
+      return {
+        event: raw.event ?? '',
+        trackId: raw.trackId ?? null,
+        uri: raw.uri ?? null,
+        name: raw.name ?? null,
+        artists: Array.isArray(raw.artists) ? raw.artists : [],
+        album: raw.album ?? null,
+        durationMs: typeof raw.durationMs === 'number' ? raw.durationMs : null,
+        positionMs: typeof raw.positionMs === 'number' ? raw.positionMs : null,
+        updatedAt: raw.updatedAt ?? '',
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  status(): SpotifyPlayerStatus {
+    const nowPlaying = this.readNowPlaying();
+    const hasStream = existsSync(join(this.hlsDir, 'index.m3u8'));
+    let state: SpotifyPlayerState;
+    if (!this.running) {
+      state = this.lastError ? 'error' : this.restartTimer ? 'connecting' : 'stopped';
+    } else if (this.deviceAuth && !this.credentialsCaptured) {
+      state = 'pairing';
+    } else {
+      state = playbackStateFromEvent(nowPlaying?.event);
+    }
+    return {
+      state,
+      deviceName: this.deviceName,
+      pairing: state === 'pairing' && this.pairing?.url && this.pairing.code ? this.pairing : null,
+      nowPlaying: state === 'playing' || state === 'paused' ? nowPlaying : null,
+      hasStream,
+      error: this.lastError,
+    };
+  }
+}
+
+export class SpotifyPlayerManager {
+  private readonly players = new Map<string, LibrespotPlayer>();
+
+  private player(userId: string, deviceName?: string): LibrespotPlayer {
+    let p = this.players.get(userId);
+    if (!p) {
+      p = new LibrespotPlayer(userId, deviceName ?? defaultDeviceName());
+      this.players.set(userId, p);
+    }
+    return p;
+  }
+
+  /** Begin device pairing and wait briefly for the code so the caller can show it. */
+  async startPairing(userId: string, opts: StartOptions = {}): Promise<SpotifyPlayerStatus> {
+    const p = this.player(userId, opts.deviceName);
+    p.startPairing(opts);
+    await p.waitForPairingCode();
+    return p.status();
+  }
+
+  ensureRunning(userId: string, credentialsJson: string, opts: { deviceName?: string } = {}): SpotifyPlayerStatus {
+    const p = this.player(userId, opts.deviceName);
+    p.ensureRunning(credentialsJson);
+    return p.status();
+  }
+
+  getStatus(userId: string): SpotifyPlayerStatus {
+    const p = this.players.get(userId);
+    if (!p) {
+      return {
+        state: 'stopped',
+        deviceName: defaultDeviceName(),
+        pairing: null,
+        nowPlaying: null,
+        hasStream: false,
+        error: null,
+      };
+    }
+    return p.status();
+  }
+
+  stop(userId: string, options: { purge?: boolean } = {}): void {
+    const p = this.players.get(userId);
+    if (!p) return;
+    p.stop(options);
+    this.players.delete(userId);
+  }
+
+  /** Absolute path of one HLS file for a user, or null if the name is not one we serve. */
+  hlsPath(userId: string, file: string): string | null {
+    if (!isSafeHlsFile(file)) return null;
+    return join(spotifyStateDir(userId), 'hls', file);
+  }
+
+  stopAll(): void {
+    for (const userId of [...this.players.keys()]) this.stop(userId);
+  }
+}
+
+/**
+ * One manager per process. Kept on globalThis so Next's dev-mode module
+ * reloads do not orphan running librespot children behind a fresh Map.
+ */
+const GLOBAL_KEY = '__bittorrentedSpotifyPlayerManager';
+
+export function getSpotifyPlayerManager(): SpotifyPlayerManager {
+  const g = globalThis as typeof globalThis & { [GLOBAL_KEY]?: SpotifyPlayerManager };
+  if (!g[GLOBAL_KEY]) {
+    const manager = new SpotifyPlayerManager();
+    g[GLOBAL_KEY] = manager;
+    for (const sig of ['SIGTERM', 'SIGINT'] as const) {
+      process.once(sig, () => manager.stopAll());
+    }
+  }
+  return g[GLOBAL_KEY];
+}

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -2284,6 +2284,33 @@ export type Database = {
         };
         Relationships: [];
       };
+      bt_spotify_sessions: {
+        Row: {
+          id: string;
+          user_id: string;
+          username: string | null;
+          credentials_enc: string;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          username?: string | null;
+          credentials_enc: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          username?: string | null;
+          credentials_enc?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       bt_siriusxm_sessions: {
         Row: {
           id: string;

--- a/supabase/migrations/20260904000000_spotify_sessions.sql
+++ b/supabase/migrations/20260904000000_spotify_sessions.sql
@@ -1,0 +1,57 @@
+-- Spotify device credentials (per user)
+-- Stores the credentials.json that librespot writes after the user pairs a
+-- code at spotify.com/pair. It is a reusable login for the whole account, so
+-- it is stored encrypted (senc:v1 envelope from src/lib/seedbox/crypto.ts)
+-- and written back to librespot's cache directory when its process starts.
+
+CREATE TABLE IF NOT EXISTS bt_spotify_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
+  username TEXT,                                -- Spotify username, for display
+  credentials_enc TEXT NOT NULL,                -- encrypted credentials.json
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_bt_spotify_sessions_user_id
+  ON bt_spotify_sessions(user_id);
+
+CREATE OR REPLACE FUNCTION bt_spotify_sessions_set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_bt_spotify_sessions_updated_at ON bt_spotify_sessions;
+CREATE TRIGGER trg_bt_spotify_sessions_updated_at
+  BEFORE UPDATE ON bt_spotify_sessions
+  FOR EACH ROW
+  EXECUTE FUNCTION bt_spotify_sessions_set_updated_at();
+
+ALTER TABLE bt_spotify_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own spotify session"
+  ON bt_spotify_sessions FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own spotify session"
+  ON bt_spotify_sessions FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own spotify session"
+  ON bt_spotify_sessions FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own spotify session"
+  ON bt_spotify_sessions FOR DELETE
+  USING (auth.uid() = user_id);
+
+COMMENT ON TABLE bt_spotify_sessions IS 'Per-user librespot credentials.json (encrypted) from Spotify device pairing.';
+COMMENT ON COLUMN bt_spotify_sessions.credentials_enc IS 'senc:v1 AES-256-GCM envelope of the credentials.json librespot caches after pairing.';


### PR DESCRIPTION
## Spotify on bittorrented.com via librespot

Each logged-in user pairs their own Spotify Premium account at `/spotify`. The server runs one `librespot` process for them, which appears as a Spotify Connect device ("BitTorrented") in their Spotify apps. Casting to it produces a live HLS stream that plays in the browser.

This is the personal rail, the analog of `/radio` where each user connects their own SiriusXM account. It is deliberately **not** wired into the resale (`iptv_shares`) machinery: the SiriusXM resale rail is sports and news only because a personal subscription does not license music to paying third parties, and Spotify is all music.

### How it works

- **Login** is Spotify's device-pairing flow. librespot prints a code, the user enters it at spotify.com/pair from any device, and librespot writes `credentials.json`. That file is stored encrypted in `bt_spotify_sessions` and written back to the cache dir on restart, so a deploy needs no re-pairing. (Spotify removed password login in 2024; the browser OAuth flow needs a localhost redirect.)
- **Audio** uses librespot's subprocess backend: it spawns `ffmpeg` itself each time the sink opens, pipes 44.1 kHz S16LE PCM into it, and ffmpeg writes a rolling HLS playlist into the user's state dir under `getTempDir()`. Pause closes the sink and ends ffmpeg; resume starts a fresh one that appends to the same playlist. Volume control is `fixed` so the phone slider does not scale the stream.
- **Now playing** comes from librespot's `--onevent` hook (written into the state dir at spawn time), so there is no Web API call, no developer app, and no quota.
- **Serving**: `GET /api/spotify/stream/{index.m3u8|seg_NNNNN.ts}` reads the current user's own HLS dir. The filename regex is the path gate.
- `GET /api/spotify/status` is also the lazy starter: the first request after a deploy brings the device back from stored credentials.

### Files

- `src/lib/spotify/librespot.ts` process manager + pure helpers; `credentials.ts` encrypted store
- `src/app/api/spotify/{status,connect,disconnect,stream/[file]}/route.ts`
- `src/app/spotify/` page; `src/hooks/use-spotify-status.ts`; sidebar entry + `SpotifyIcon`
- `supabase/migrations/20260904000000_spotify_sessions.sql` + `types.ts` entry
- `Dockerfile`: new `librespot` stage. Device pairing is not in the v0.8.0 tag, so it builds a pinned git commit with rustls (no OpenSSL on musl). Adds a few minutes to a cold image build.
- `.env.example`: `LIBRESPOT_PATH`, `SPOTIFY_DEVICE_NAME`

### Verified

- `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build` (see PR checks)
- `librespot.integration.test.ts` drives the real binary through the manager (skipped unless `LIBRESPOT_PATH` is set): the argument set is accepted and a pairing code comes back.
- The Docker `librespot` stage builds on `rust:1-alpine`.

### Not verified here

End-to-end audio needs a Premium account paired on a running instance. I could not do that without your Spotify login; pairing takes one visit to spotify.com/pair after deploy.

### Follow-ups, if wanted

- Server-side control (pick a playlist from the site) needs a Spotify developer app and the Web API player endpoints; the owner must hold Premium and dev mode caps at 5 users.
- Resale (`kind='spotify'` on `iptv_shares`) would be a `resolveUpstreamForSession` branch pointing at the owner's HLS dir, but see the licensing note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYpapwJiMXQCSBob4cyLZU
