### PR TITLE
Make the session-refresh test own every Supabase env var it reads

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -200,8 +200,14 @@ describe('Supabase session refresh and referral cookie', () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
+    // Stub every variable refreshSession can read. The code prefers
+    // NEXT_PUBLIC_SUPABASE_ANON_KEY over SUPABASE_ANON_KEY (and SUPABASE_URL
+    // over NEXT_PUBLIC_SUPABASE_URL), so stubbing only one of each pair lets a
+    // real key in the environment (CI has one) win over the test's value.
     vi.stubEnv('SUPABASE_URL', SUPABASE_URL);
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', SUPABASE_URL);
     vi.stubEnv('SUPABASE_ANON_KEY', 'anon-key');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'anon-key');
     fetchMock.mockReset();
     fetchMock.mockResolvedValue(
       new Response(JSON.stringify({ access_token: jwt(3600), refresh_token: 'new-refresh', expires_in: 3600, token_type: 'bearer' }), {


### PR DESCRIPTION
## Fix for the deterministic CI failure introduced by #205

`Run Tests` on master (runs 33978537165, 33978629242) failed on
`src/proxy.test.ts > Supabase session refresh and referral cookie > refreshes an expiring session for a browser and writes the new tokens back` with `expected '***' to be 'anon-key'`, which blocks the droplet deploy.

**Cause.** `refreshSession` reads `process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY` at call time. The test stubbed only `SUPABASE_ANON_KEY`, so in CI the real `NEXT_PUBLIC_SUPABASE_ANON_KEY` won. The URL pair has the opposite precedence (`SUPABASE_URL` first), which is why that assertion passed. Not an import-time read; the env is read lazily inside the function.

**Fix.** The test stubs all four variables (`SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_ANON_KEY`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`) in `beforeEach` and unstubs in `afterEach`, so it owns every value the code can read. One-file change, no production code touched.

**Proof.**
- Pre-fix test with `NEXT_PUBLIC_SUPABASE_ANON_KEY=real-looking-key NEXT_PUBLIC_SUPABASE_URL=https://x.supabase.co`: 1 failed, `expected 'real-looking-key' to be 'anon-key'` (CI's failure reproduced).
- Fixed test with those set (plus `SUPABASE_URL`/`SUPABASE_ANON_KEY` set to other values): 27 passed.
- Fixed test with all four unset: 27 passed.
- `pnpm test`: 2731 passed, 9 skipped, 0 failed. `pnpm typecheck`: clean. `pnpm lint`: 0 errors (248 pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJaXiqE9BDoNfoJBhfXroC
