### PR TITLE
Blog pages carry a CrawlProof unit by default

### DIFF
--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,7 +1,18 @@
 'use client';
 
+import { AdUnit } from '@/components/ads/ad-unit';
 import { MainLayout } from '@/components/layout';
 
+/**
+ * Every blog page carries one CrawlProof unit under the post: the text strip,
+ * which collapses to nothing when there is no advertiser and, like every
+ * AdUnit here, renders nothing for signed-in members.
+ */
 export default function BlogLayout({ children }: { children: React.ReactNode }) {
-  return <MainLayout>{children}</MainLayout>;
+  return (
+    <MainLayout>
+      {children}
+      <AdUnit format="text_link" className="flex justify-center" />
+    </MainLayout>
+  );
 }


### PR DESCRIPTION
Every blog we run carries CrawlProof tracking and one ad unit by default. bittorrented.com had the tracker and an AdUnit on other pages; this appends the text-strip unit under every blog post (same auth-gated component, so members see nothing).

Part of the fleet sweep alongside nichedb.dev, hqtui, c0mpute, pairux, c0upons and d0rz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YafYxayh7Gqe5MWNNQMev2