### PR TITLE
Connect nixamp with OAuth 2.1, and put a watch party on it as a room

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -255,6 +255,23 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_OAUTH_REDIRECT_URI=https://your-host/api/youtube/auth/callback
 
+# nixamp (nixamp.com) — OAuth 2.1, with nixamp as the authorization server and
+# bittorrented.com as the client. Connecting one lets a watch party here become
+# a room on nixamp, joinable from every nixamp surface.
+#
+# 1. nixamp ships knowing `bittorrented` and its redirect URIs, so in production
+#    nothing below needs setting: the defaults are https://nixamp.com and
+#    <NEXT_PUBLIC_APP_URL>/api/v1/nixamp/oauth/callback.
+# 2. For a staging host, register it on the nixamp side with NIXAMP_OAUTH_CLIENTS
+#    and set NIXAMP_OAUTH_REDIRECT_URI here to match it exactly — OAuth 2.1
+#    matches redirect URIs byte for byte.
+# 3. NIXAMP_CLIENT_SECRET is only for a confidential registration. Leave it empty:
+#    PKCE (which is mandatory either way) is what protects the exchange.
+NIXAMP_SITE=https://nixamp.com
+NIXAMP_CLIENT_ID=bittorrented
+NIXAMP_CLIENT_SECRET=
+NIXAMP_OAUTH_REDIRECT_URI=https://your-host/api/v1/nixamp/oauth/callback
+
 # DHT Crawler (Bitmagnet + DHT Search API)
 # Uses existing SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_DB_PASSWORD
 # Set to false to skip DHT services installation during setup

--- a/src/app/api/v1/nixamp/connection/route.ts
+++ b/src/app/api/v1/nixamp/connection/route.ts
@@ -1,0 +1,41 @@
+/**
+ * GET    /api/v1/nixamp/connection  — is a nixamp account connected, and whose
+ * DELETE /api/v1/nixamp/connection  — disconnect it, here and on nixamp
+ *
+ * What the settings page reads and what its Disconnect button calls. The
+ * answer never carries a token: the page needs to know that a connection
+ * exists and what to call the person, and nothing else.
+ */
+
+import { NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth';
+import { disconnectNixampAccount, getNixampAccount, isNixampConfigured } from '@/lib/nixamp';
+
+export async function GET(): Promise<NextResponse> {
+  const user = await getCurrentUser();
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const account = await getNixampAccount(user.id);
+  return NextResponse.json({
+    configured: isNixampConfigured(),
+    connected: Boolean(account),
+    ...(account
+      ? {
+          connection: {
+            // The public name on nixamp. Falling back to the id rather than
+            // the address, which is a credential over there.
+            handle: account.handle || account.nixampSub,
+            site: account.nixampSite,
+            scopes: account.scopes,
+          },
+        }
+      : {}),
+  });
+}
+
+export async function DELETE(): Promise<NextResponse> {
+  const user = await getCurrentUser();
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const gone = await disconnectNixampAccount(user.id);
+  return NextResponse.json({ success: true, disconnected: gone });
+}

--- a/src/app/api/v1/nixamp/oauth/callback/route.ts
+++ b/src/app/api/v1/nixamp/oauth/callback/route.ts
@@ -1,0 +1,96 @@
+/**
+ * GET /api/v1/nixamp/oauth/callback
+ *
+ * Where nixamp sends the browser back. This is the exact path registered with
+ * nixamp, which matches it byte for byte, so it is not something to rename
+ * lightly: the OAuth 2.1 rule is exact matching, with only a loopback port
+ * allowed to vary.
+ *
+ * The state and the PKCE verifier come out of the httpOnly cookie set on the
+ * way out, and the cookie is cleared however this ends: a verifier is worth
+ * exactly one exchange.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth';
+import {
+  discover,
+  exchangeCodeForTokens,
+  fetchUserInfo,
+  getNixampOAuthConfig,
+  NIXAMP_OAUTH_STATE_COOKIE,
+  upsertNixampAccount,
+} from '@/lib/nixamp';
+
+const SETTINGS = '/settings?tab=connections';
+
+function back(origin: string, params: Record<string, string>): NextResponse {
+  const url = new URL(SETTINGS, origin);
+  for (const [name, value] of Object.entries(params)) url.searchParams.set(name, value);
+  const res = NextResponse.redirect(url);
+  res.cookies.delete(NIXAMP_OAUTH_STATE_COOKIE);
+  return res;
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  // The public origin, from the configured redirect URI rather than
+  // request.url, which behind a proxy can be the internal bind address.
+  let origin: string;
+  let config;
+  try {
+    config = getNixampOAuthConfig(new URL(request.url).origin);
+    origin = new URL(config.redirectUri).origin;
+  } catch {
+    return back(new URL(request.url).origin, { nixamp_error: 'server_misconfigured' });
+  }
+
+  const user = await getCurrentUser();
+  if (!user) return back(origin, { nixamp_error: 'not_authenticated' });
+
+  const { searchParams } = new URL(request.url);
+  const refused = searchParams.get('error');
+  if (refused) return back(origin, { nixamp_error: refused });
+
+  const code = searchParams.get('code');
+  const state = searchParams.get('state');
+  if (!code || !state) return back(origin, { nixamp_error: 'missing_code_or_state' });
+
+  const cookie = request.cookies.get(NIXAMP_OAUTH_STATE_COOKIE)?.value;
+  let kept: { state?: string; verifier?: string } = {};
+  try {
+    kept = cookie ? (JSON.parse(cookie) as typeof kept) : {};
+  } catch {
+    kept = {};
+  }
+  // Both halves, and the state compared rather than merely present: a
+  // callback whose state we did not issue is somebody replaying a URL.
+  if (!kept.state || !kept.verifier || kept.state !== state) {
+    return back(origin, { nixamp_error: 'state_mismatch' });
+  }
+
+  try {
+    const metadata = await discover(config);
+    const tokens = await exchangeCodeForTokens(config, metadata, code, kept.verifier);
+    const who = await fetchUserInfo(metadata, tokens.access_token);
+
+    await upsertNixampAccount({
+      userId: user.id,
+      nixampSub: who.sub,
+      nixampSite: config.site,
+      // The handle, never the address: on nixamp the account email is the
+      // linking key and is treated as a credential, and the handle is the
+      // name that is safe to show a room full of strangers.
+      ...(who.handle ? { handle: who.handle } : {}),
+      ...(who.email ? { email: who.email } : {}),
+      accessToken: tokens.access_token,
+      ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
+      expiresIn: tokens.expires_in,
+      scopes: tokens.scope ? tokens.scope.split(' ').filter(Boolean) : [],
+    });
+
+    return back(origin, { nixamp: 'connected' });
+  } catch (err) {
+    console.error('[nixamp OAuth] callback failed:', err);
+    return back(origin, { nixamp_error: 'exchange_failed' });
+  }
+}

--- a/src/app/api/v1/nixamp/oauth/start/route.ts
+++ b/src/app/api/v1/nixamp/oauth/start/route.ts
@@ -1,0 +1,59 @@
+/**
+ * GET /api/v1/nixamp/oauth/start
+ *
+ * Begins the OAuth 2.1 flow that connects a nixamp account to this one.
+ * nixamp is the authorization server; we are the client.
+ *
+ * Two secrets go out in one httpOnly cookie and neither ever reaches the
+ * browser's JavaScript: the CSRF state, which proves the callback belongs to
+ * a flow we started, and the PKCE verifier, which proves the code exchange is
+ * being done by whoever started it. OAuth 2.1 requires the second of every
+ * client, and it is what makes a client secret unnecessary here.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth';
+import {
+  buildAuthUrl,
+  codeChallenge,
+  discover,
+  generateCodeVerifier,
+  generateState,
+  getNixampOAuthConfig,
+  NIXAMP_OAUTH_STATE_COOKIE,
+  NIXAMP_OAUTH_STATE_MAX_AGE_SECONDS,
+} from '@/lib/nixamp';
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const origin = new URL(request.url).origin;
+  const user = await getCurrentUser();
+  if (!user) {
+    // Connecting is an act of an account: there has to be one to connect TO.
+    const back = new URL('/login', origin);
+    back.searchParams.set('redirect', '/settings?tab=connections');
+    return NextResponse.redirect(back);
+  }
+
+  let config;
+  try {
+    config = getNixampOAuthConfig(origin);
+  } catch (err) {
+    console.error('[nixamp OAuth] Missing config:', err);
+    return NextResponse.json({ error: 'The nixamp connection is not configured on this server.' }, { status: 500 });
+  }
+
+  const state = generateState();
+  const verifier = generateCodeVerifier();
+  const metadata = await discover(config);
+  const authUrl = buildAuthUrl(config, metadata, state, await codeChallenge(verifier));
+
+  const response = NextResponse.redirect(authUrl);
+  response.cookies.set(NIXAMP_OAUTH_STATE_COOKIE, JSON.stringify({ state, verifier }), {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: NIXAMP_OAUTH_STATE_MAX_AGE_SECONDS,
+  });
+  return response;
+}

--- a/src/app/api/watch-party/nixamp/route.test.ts
+++ b/src/app/api/watch-party/nixamp/route.test.ts
@@ -1,0 +1,152 @@
+/**
+ * The bridge endpoint: who may put a party on nixamp, and who may only read
+ * where the room is.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const auth = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
+const store = vi.hoisted(() => ({ getParty: vi.fn() }));
+const nixamp = vi.hoisted(() => ({
+  bridgeParty: vi.fn(),
+  endBridgedParty: vi.fn(),
+  getBridgedRoom: vi.fn(),
+  pushPlayback: vi.fn(),
+  NixampNotConnected: class NixampNotConnected extends Error {},
+  NixampConnectionLost: class NixampConnectionLost extends Error {},
+}));
+
+vi.mock('@/lib/auth', () => auth);
+vi.mock('../_store', () => store);
+vi.mock('@/lib/nixamp', () => nixamp);
+vi.mock('@/lib/watch-party', () => ({
+  validatePartyCode: (code: string) => /^[A-Z0-9]{6}$/.test(code),
+}));
+
+const { GET, POST } = await import('./route');
+
+const room = {
+  partyCode: 'ABC123',
+  nixampSite: 'https://nixamp.test',
+  eventId: 'event-1',
+  roomId: 'event-abc',
+  slug: 'dune-together',
+  nixampUrl: 'https://nixamp.test/live/dune-together',
+};
+
+const party = {
+  code: 'ABC123',
+  hostId: 'user-1',
+  mediaTitle: 'Dune (2021)',
+  playback: { currentTime: 930, isPlaying: true, duration: 9000, lastUpdate: Date.now() },
+};
+
+function post(body: unknown): NextRequest {
+  return new NextRequest('https://bittorrented.test/api/watch-party/nixamp', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.getCurrentUser.mockResolvedValue({ id: 'user-1', email: 'a@b.test' });
+  store.getParty.mockReturnValue(party);
+  nixamp.getBridgedRoom.mockResolvedValue(null);
+  nixamp.bridgeParty.mockResolvedValue(room);
+  nixamp.pushPlayback.mockResolvedValue(true);
+  nixamp.endBridgedParty.mockResolvedValue(true);
+});
+
+describe('GET', () => {
+  it('tells anybody where the room is, without an account', async () => {
+    auth.getCurrentUser.mockResolvedValue(null);
+    nixamp.getBridgedRoom.mockResolvedValue(room);
+    const res = await GET(new NextRequest('https://bittorrented.test/api/watch-party/nixamp?code=ABC123'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.bridged).toBe(true);
+    expect(body.room.nixampUrl).toBe(room.nixampUrl);
+  });
+
+  it('answers "not bridged" rather than an error, because most parties are not', async () => {
+    const res = await GET(new NextRequest('https://bittorrented.test/api/watch-party/nixamp?code=ABC123'));
+    expect(res.status).toBe(200);
+    expect((await res.json()).bridged).toBe(false);
+  });
+
+  it('will not take a code that is not one', async () => {
+    const res = await GET(new NextRequest('https://bittorrented.test/api/watch-party/nixamp?code=nope'));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST', () => {
+  it('needs somebody signed in', async () => {
+    auth.getCurrentUser.mockResolvedValue(null);
+    const res = await POST(post({ code: 'ABC123' }));
+    expect(res.status).toBe(401);
+    expect(nixamp.bridgeParty).not.toHaveBeenCalled();
+  });
+
+  it('refuses a member who is not the host of the party', async () => {
+    auth.getCurrentUser.mockResolvedValue({ id: 'user-2', email: 'c@d.test' });
+    const res = await POST(post({ code: 'ABC123' }));
+    expect(res.status).toBe(403);
+    expect(nixamp.bridgeParty).not.toHaveBeenCalled();
+  });
+
+  it('bridges for the host and answers the room link', async () => {
+    const res = await POST(post({ code: 'ABC123' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.room.nixampUrl).toBe(room.nixampUrl);
+    expect(nixamp.bridgeParty).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1', partyCode: 'ABC123', mediaTitle: 'Dune (2021)' })
+    );
+  });
+
+  it('sends nixamp somewhere real when a sync says nothing about where it is', async () => {
+    const res = await POST(post({ code: 'ABC123', action: 'sync' }));
+    expect(res.status).toBe(200);
+    // Falls back to the party's own recorded playback rather than 0, which
+    // would drag everybody on nixamp back to the start of the film.
+    expect(nixamp.pushPlayback).toHaveBeenCalledWith(
+      expect.objectContaining({ positionSeconds: 930, playing: true })
+    );
+  });
+
+  it('reports a sync that did not land without calling the party broken', async () => {
+    nixamp.pushPlayback.mockResolvedValue(false);
+    const res = await POST(post({ code: 'ABC123', action: 'sync', positionSeconds: 12, playing: false }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).synced).toBe(false);
+  });
+
+  it('points at the connect flow when no nixamp account is connected', async () => {
+    nixamp.bridgeParty.mockRejectedValue(new nixamp.NixampNotConnected());
+    const res = await POST(post({ code: 'ABC123' }));
+    expect(res.status).toBe(409);
+    expect((await res.json()).connect).toBe('/api/v1/nixamp/oauth/start');
+  });
+
+  it('says to connect again when the grant has been withdrawn', async () => {
+    nixamp.bridgeParty.mockRejectedValue(new nixamp.NixampConnectionLost());
+    const res = await POST(post({ code: 'ABC123' }));
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toMatch(/connection has ended/i);
+  });
+
+  it('404s for a party this process has never heard of', async () => {
+    store.getParty.mockReturnValue(undefined);
+    const res = await POST(post({ code: 'ABC123' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('will not take an action it does not have', async () => {
+    const res = await POST(post({ code: 'ABC123', action: 'delete-everything' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/watch-party/nixamp/route.ts
+++ b/src/app/api/watch-party/nixamp/route.ts
@@ -1,0 +1,150 @@
+/**
+ * The bridge between a watch party here and a room on nixamp.
+ *
+ *   GET  /api/watch-party/nixamp?code=ABC123   where the room is (public)
+ *   POST /api/watch-party/nixamp               bridge, sync or end (host only)
+ *
+ * The film stays here; the room goes there. Once a party is bridged, anybody
+ * on nixamp -- the web app, the terminal, the desktop app, a television, an
+ * agent over MCP -- can find it and be in the room with the people watching
+ * in this browser.
+ *
+ * GET is public on purpose: a member who was handed a code needs the room
+ * link, and that link is not a secret -- the room's own visibility on nixamp
+ * is what decides who may be in it.
+ *
+ * POST is the host, proven twice: the signed-in user must be the one whose
+ * nixamp account is connected, and must be the host of the party as the
+ * in-memory store has it. Neither alone is enough -- the store's hostId can
+ * be a guest string, and a connected nixamp account says nothing about which
+ * party is yours.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth';
+import { validatePartyCode } from '@/lib/watch-party';
+import {
+  NixampConnectionLost,
+  NixampNotConnected,
+  bridgeParty,
+  endBridgedParty,
+  getBridgedRoom,
+  pushPlayback,
+} from '@/lib/nixamp';
+import { getParty } from '../_store';
+
+interface BridgeBody {
+  code?: string;
+  action?: 'bridge' | 'sync' | 'end';
+  title?: string;
+  mediaTitle?: string;
+  positionSeconds?: number;
+  playing?: boolean;
+}
+
+function cleanCode(value: string | null | undefined): string | null {
+  const code = (value ?? '').trim().toUpperCase();
+  return code && validatePartyCode(code) ? code : null;
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const code = cleanCode(new URL(request.url).searchParams.get('code'));
+  if (!code) return NextResponse.json({ error: 'A valid party code is required' }, { status: 400 });
+
+  const room = await getBridgedRoom(code);
+  if (!room) {
+    // Not an error: most parties are never bridged, and the page asks about
+    // every one it shows.
+    return NextResponse.json({ success: true, bridged: false });
+  }
+  return NextResponse.json({
+    success: true,
+    bridged: true,
+    room: { nixampUrl: room.nixampUrl, roomId: room.roomId, slug: room.slug, site: room.nixampSite },
+  });
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json(
+      { error: 'Sign in, then connect a nixamp account, to put this party on nixamp.' },
+      { status: 401 }
+    );
+  }
+
+  let body: BridgeBody;
+  try {
+    body = (await request.json()) as BridgeBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const code = cleanCode(body.code);
+  if (!code) return NextResponse.json({ error: 'A valid party code is required' }, { status: 400 });
+
+  const party = getParty(code);
+  if (!party) return NextResponse.json({ error: 'Party not found' }, { status: 404 });
+  if (party.hostId !== user.id) {
+    return NextResponse.json({ error: 'Only the host can put this party on nixamp' }, { status: 403 });
+  }
+
+  const origin = new URL(request.url).origin;
+  const action = body.action ?? 'bridge';
+
+  try {
+    if (action === 'bridge') {
+      const room = await bridgeParty({
+        userId: user.id,
+        partyCode: code,
+        title: body.title ?? party.mediaTitle ?? `Watch party ${code}`,
+        mediaTitle: body.mediaTitle ?? party.mediaTitle ?? '',
+        origin,
+      });
+      return NextResponse.json({
+        success: true,
+        bridged: true,
+        room: { nixampUrl: room.nixampUrl, roomId: room.roomId, slug: room.slug, site: room.nixampSite },
+      });
+    }
+
+    if (action === 'sync') {
+      // Where the host's own player is. Falling back to the party's recorded
+      // playback so a client that only says "sync" still says something true.
+      const positionSeconds =
+        typeof body.positionSeconds === 'number' ? body.positionSeconds : party.playback.currentTime;
+      const playing = typeof body.playing === 'boolean' ? body.playing : party.playback.isPlaying;
+      const landed = await pushPlayback({
+        userId: user.id,
+        partyCode: code,
+        positionSeconds,
+        playing,
+        ...(body.mediaTitle ?? party.mediaTitle ? { mediaTitle: body.mediaTitle ?? party.mediaTitle } : {}),
+      });
+      // A sync that did not land is not a failure of the party: everybody in
+      // this browser is still together. It is only nixamp that is behind.
+      return NextResponse.json({ success: true, synced: landed });
+    }
+
+    if (action === 'end') {
+      return NextResponse.json({ success: true, ended: await endBridgedParty(user.id, code) });
+    }
+
+    return NextResponse.json({ error: 'action must be bridge, sync or end' }, { status: 400 });
+  } catch (error) {
+    if (error instanceof NixampNotConnected) {
+      return NextResponse.json(
+        { error: 'Connect your nixamp account first.', connect: '/api/v1/nixamp/oauth/start' },
+        { status: 409 }
+      );
+    }
+    if (error instanceof NixampConnectionLost) {
+      return NextResponse.json(
+        { error: 'That nixamp connection has ended. Connect it again.', connect: '/api/v1/nixamp/oauth/start' },
+        { status: 409 }
+      );
+    }
+    console.error('[WatchParty] nixamp bridge failed:', error);
+    return NextResponse.json({ error: 'Could not reach nixamp' }, { status: 502 });
+  }
+}

--- a/src/app/api/watch-party/route.ts
+++ b/src/app/api/watch-party/route.ts
@@ -10,6 +10,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth';
 import {
   createWatchParty,
   validatePartyCode,
@@ -42,8 +43,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    // Generate a guest ID if not provided (for anonymous users)
-    const hostId = body.hostId ?? `guest_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+    // Whoever is signed in IS the host, ahead of anything the body claims.
+    //
+    // A party still needs no account -- an anonymous host gets a guest id as
+    // before -- but a signed-in one gets their real user id, and that is what
+    // makes the nixamp bridge possible: putting the party on nixamp has to be
+    // provably the host's doing, and a guest string proves nothing.
+    const user = await getCurrentUser();
+    const hostId =
+      user?.id ?? body.hostId ?? `guest_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
 
     // Create the party options
     const options: CreatePartyOptions = {

--- a/src/app/settings/connections-section.tsx
+++ b/src/app/settings/connections-section.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+/**
+ * Connected accounts — other places that act on your behalf, or you on theirs.
+ *
+ * Today that is nixamp: bittorrented.com is an OAuth 2.1 client of nixamp.com,
+ * so connecting one lets a watch party here become a room there, joinable from
+ * every nixamp surface.
+ *
+ * The name shown is the nixamp HANDLE, never the address. On nixamp the
+ * account email is the OAuth linking key and is treated as a credential; the
+ * handle is the name that is safe to show.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { cn } from '@/lib/utils';
+import { CheckIcon, LinkIcon, LoadingSpinner, TrashIcon } from '@/components/ui/icons';
+
+interface Connection {
+  handle: string;
+  site: string;
+  scopes: string[];
+}
+
+interface ConnectionResponse {
+  configured?: boolean;
+  connected?: boolean;
+  connection?: Connection;
+  error?: string;
+}
+
+/** The words the callback puts in the URL, in words a person would use. */
+const REASONS: Record<string, string> = {
+  access_denied: 'You said not now on nixamp. Nothing was connected.',
+  state_mismatch: 'That sign-in link had expired. Try connecting again.',
+  not_authenticated: 'You were signed out partway through. Sign in and try again.',
+  server_misconfigured: 'This server has no nixamp settings yet.',
+  exchange_failed: 'nixamp would not finish the connection. Try again.',
+  missing_code_or_state: 'nixamp sent an incomplete answer. Try again.',
+};
+
+export function ConnectionsSection(): React.ReactElement {
+  const searchParams = useSearchParams();
+  const [state, setState] = useState<ConnectionResponse | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (): Promise<ConnectionResponse> => {
+    try {
+      const res = await fetch('/api/v1/nixamp/connection');
+      const body = (await res.json()) as ConnectionResponse;
+      return res.ok ? body : { connected: false, configured: false };
+    } catch {
+      return { connected: false, configured: false };
+    }
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      const answer = await load();
+      if (alive) setState(answer);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [load]);
+
+  const disconnect = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/v1/nixamp/connection', { method: 'DELETE' });
+      if (!res.ok) setError('Could not disconnect. Try again.');
+      setState(await load());
+    } finally {
+      setBusy(false);
+    }
+  }, [load]);
+
+  const justConnected = searchParams.get('nixamp') === 'connected';
+  const refusal = searchParams.get('nixamp_error');
+
+  if (state === null) {
+    return (
+      <div className="flex items-center gap-2 text-text-muted">
+        <LoadingSpinner size={16} /> Checking your connections…
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold text-text-primary">Connected accounts</h2>
+        <p className="text-sm text-text-secondary">
+          Other places that can act for you here, or that you can act on from here.
+        </p>
+      </div>
+
+      {justConnected ? (
+        <p className="flex items-center gap-2 text-sm text-green-500">
+          <CheckIcon size={16} /> nixamp is connected.
+        </p>
+      ) : null}
+      {refusal ? (
+        <p className="text-sm text-status-error">{REASONS[refusal] ?? `nixamp said: ${refusal}`}</p>
+      ) : null}
+
+      <div className="rounded-xl bg-bg-secondary border border-border-subtle p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="font-semibold text-text-primary flex items-center gap-2">
+              <LinkIcon size={16} /> nixamp
+            </h3>
+            <p className="text-sm text-text-secondary mt-1">
+              {state.connected
+                ? 'A watch party here can be a room on nixamp, joinable from the nixamp app, a terminal, the desktop app or a TV.'
+                : 'Connect nixamp and a watch party here becomes a room people can join from any nixamp client.'}
+            </p>
+            {state.connected && state.connection ? (
+              <p className="text-sm text-text-muted mt-2">
+                Connected as{' '}
+                <span className="font-mono text-accent-primary">@{state.connection.handle}</span> on{' '}
+                {state.connection.site.replace(/^https?:\/\//, '')}
+                {state.connection.scopes.length > 0 ? ` · ${state.connection.scopes.join(', ')}` : ''}
+              </p>
+            ) : null}
+          </div>
+
+          {state.connected ? (
+            <button
+              onClick={() => void disconnect()}
+              disabled={busy}
+              className={cn(
+                'flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors',
+                'text-text-muted hover:text-status-error hover:bg-status-error/10',
+                busy && 'opacity-50 cursor-not-allowed'
+              )}
+            >
+              <TrashIcon size={16} /> Disconnect
+            </button>
+          ) : (
+            // A link and not a fetch: connecting is a round trip through
+            // nixamp's own consent page, which is the only place the decision
+            // can honestly be made.
+            <a
+              href="/api/v1/nixamp/oauth/start"
+              className={cn(
+                'px-4 py-2 rounded-lg text-sm whitespace-nowrap transition-colors',
+                state.configured
+                  ? 'bg-accent-primary text-white hover:bg-accent-primary/90'
+                  : 'bg-bg-tertiary text-text-muted pointer-events-none'
+              )}
+            >
+              {state.configured ? 'Connect nixamp' : 'Not configured'}
+            </a>
+          )}
+        </div>
+      </div>
+
+      {error ? <p className="text-sm text-status-error">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/app/settings/settings-content.tsx
+++ b/src/app/settings/settings-content.tsx
@@ -11,12 +11,13 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { MainLayout } from '@/components/layout';
 import { cn } from '@/lib/utils';
-import { SettingsIcon, UserIcon, TvIcon, VideoIcon, TrashIcon, ExternalLinkIcon, LoadingSpinner, MailIcon } from '@/components/ui/icons';
+import { SettingsIcon, UserIcon, TvIcon, VideoIcon, TrashIcon, ExternalLinkIcon, LoadingSpinner, MailIcon, LinkIcon } from '@/components/ui/icons';
 import { useAuth } from '@/hooks/use-auth';
 import Link from 'next/link';
 import { EmailAccountsSection } from './email-accounts-section';
+import { ConnectionsSection } from './connections-section';
 
-type SettingsTab = 'account' | 'playback' | 'iptv' | 'email';
+type SettingsTab = 'account' | 'playback' | 'iptv' | 'email' | 'connections';
 
 /**
  * IPTV Playlist data from API
@@ -56,11 +57,12 @@ export function SettingsContent(): React.ReactElement {
     { id: 'playback' as const, label: 'Playback', icon: VideoIcon },
     { id: 'iptv' as const, label: 'IPTV', icon: TvIcon },
     { id: 'email' as const, label: 'Email', icon: MailIcon },
+    { id: 'connections' as const, label: 'Connections', icon: LinkIcon },
   ];
 
   const tabParam = searchParams.get('tab');
   const activeTab: SettingsTab =
-    tabParam === 'email' || tabParam === 'playback' || tabParam === 'iptv'
+    tabParam === 'email' || tabParam === 'playback' || tabParam === 'iptv' || tabParam === 'connections'
       ? tabParam
       : 'account';
 
@@ -388,6 +390,8 @@ export function SettingsContent(): React.ReactElement {
             )}
 
             {activeTab === 'email' && <EmailAccountsSection />}
+
+            {activeTab === 'connections' && <ConnectionsSection />}
           </div>
         </div>
       </div>

--- a/src/app/watch-party/page.tsx
+++ b/src/app/watch-party/page.tsx
@@ -7,8 +7,9 @@
  * Free for anyone without requiring login.
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { MainLayout } from '@/components/layout';
+import { NixampPanel } from '@/components/watch-party';
 import { cn } from '@/lib/utils';
 import { PartyIcon, PlusIcon, UsersIcon } from '@/components/ui/icons';
 
@@ -65,6 +66,9 @@ export default function WatchPartyPage(): React.ReactElement {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [, setIsMediaModalOpen] = useState(false);
+  // The host's own player, so its position can be told to nixamp. Everybody
+  // else follows; only the host states where the film is.
+  const videoRef = useRef<HTMLVideoElement | null>(null);
 
   const handleCreateParty = useCallback(async () => {
     if (!hostName.trim()) {
@@ -224,6 +228,7 @@ export default function WatchPartyPage(): React.ReactElement {
               )}>
                 {party.mediaUrl ? (
                   <video
+                    ref={videoRef}
                     src={party.mediaUrl}
                     controls={isHost || !party.settings.hostOnlyControl}
                     className="w-full h-full rounded-xl"
@@ -258,6 +263,21 @@ export default function WatchPartyPage(): React.ReactElement {
 
             {/* Chat & Members Sidebar */}
             <div className="space-y-4">
+              {/* The same party, as a nixamp room */}
+              <NixampPanel
+                partyCode={party.code}
+                isHost={isHost}
+                mediaTitle={party.mediaTitle}
+                positionSeconds={
+                  isHost
+                    ? () => ({
+                        positionSeconds: videoRef.current?.currentTime ?? 0,
+                        playing: videoRef.current ? !videoRef.current.paused : false,
+                      })
+                    : undefined
+                }
+              />
+
               {/* Members List */}
               <div className="rounded-xl bg-bg-secondary border border-border-subtle p-4">
                 <h3 className="font-semibold text-text-primary mb-3">

--- a/src/components/watch-party/index.ts
+++ b/src/components/watch-party/index.ts
@@ -5,3 +5,4 @@
  */
 
 export { MediaSelectionModal } from './media-selection-modal';
+export { NixampPanel, type NixampPanelProps } from './nixamp-panel';

--- a/src/components/watch-party/nixamp-panel.tsx
+++ b/src/components/watch-party/nixamp-panel.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+/**
+ * "Also on nixamp" — the watch party as a room every nixamp client can join.
+ *
+ * The film stays here. What goes to nixamp is the room: whoever is in it, the
+ * chat, and the second the host's player is at. That is why the host sees a
+ * Sync button and a member sees only a link — the position is the host's to
+ * state, and everybody else's to follow.
+ *
+ * The panel is quiet until it has something to say. A party that is not
+ * bridged and a viewer who is not the host get nothing at all rather than an
+ * empty box explaining what could have been there.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface NixampPanelProps {
+  partyCode: string;
+  isHost: boolean;
+  /** Where the host's own player is, asked for at the moment of a sync. */
+  positionSeconds?: () => { positionSeconds: number; playing: boolean };
+  mediaTitle?: string;
+}
+
+interface Room {
+  nixampUrl: string;
+  roomId: string;
+  slug: string;
+  site: string;
+}
+
+interface BridgeAnswer {
+  bridged?: boolean;
+  room?: Room;
+  synced?: boolean;
+  error?: string;
+  /** Where to go when the answer is "connect nixamp first". */
+  connect?: string;
+}
+
+/** How often the host's position is pushed while a bridged party is playing. */
+const SYNC_EVERY_MS = 15_000;
+
+export function NixampPanel({ partyCode, isHost, positionSeconds, mediaTitle }: NixampPanelProps): React.ReactElement | null {
+  const [room, setRoom] = useState<Room | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [connectAt, setConnectAt] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  // Held in a ref so the interval below always reads the current getter
+  // without being torn down and rebuilt every time the player ticks. Written
+  // in an effect rather than during render: a ref touched while rendering is
+  // a value React is free to have already read.
+  const positionRef = useRef(positionSeconds);
+  useEffect(() => {
+    positionRef.current = positionSeconds;
+  }, [positionSeconds]);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/watch-party/nixamp?code=${encodeURIComponent(partyCode)}`);
+        const body = (await res.json()) as BridgeAnswer;
+        if (alive && body.bridged && body.room) setRoom(body.room);
+      } catch {
+        // Not bridged, as far as anybody here is concerned.
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [partyCode]);
+
+  const post = useCallback(
+    async (payload: Record<string, unknown>): Promise<BridgeAnswer | null> => {
+      const res = await fetch('/api/watch-party/nixamp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: partyCode, ...payload }),
+      });
+      const body = (await res.json().catch(() => ({}))) as BridgeAnswer;
+      if (!res.ok) {
+        setError(body.error ?? 'nixamp would not answer');
+        setConnectAt(body.connect ?? null);
+        return null;
+      }
+      setError(null);
+      setConnectAt(null);
+      return body;
+    },
+    [partyCode]
+  );
+
+  const bridge = useCallback(async () => {
+    setBusy(true);
+    try {
+      const body = await post({ action: 'bridge', ...(mediaTitle ? { mediaTitle, title: mediaTitle } : {}) });
+      if (body?.room) setRoom(body.room);
+    } finally {
+      setBusy(false);
+    }
+  }, [post, mediaTitle]);
+
+  const sync = useCallback(async () => {
+    const where = positionRef.current?.();
+    await post({ action: 'sync', ...(where ?? {}) });
+  }, [post]);
+
+  // While a host holds a bridged party, the position goes over on its own.
+  // Somebody opening the room from a terminal an hour in should land an hour
+  // in, and asking the host to press a button for that would not happen.
+  useEffect(() => {
+    if (!room || !isHost || !positionRef.current) return;
+    const timer = setInterval(() => void sync(), SYNC_EVERY_MS);
+    return () => clearInterval(timer);
+  }, [room, isHost, sync]);
+
+  const copy = useCallback(() => {
+    if (!room) return;
+    void navigator.clipboard?.writeText(room.nixampUrl).then(
+      () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      },
+      () => setError('could not copy that')
+    );
+  }, [room]);
+
+  // Nothing to show and nothing to offer.
+  if (!room && !isHost) return null;
+
+  return (
+    <div className="rounded-xl bg-bg-secondary border border-border-subtle p-4">
+      <h3 className="font-semibold text-text-primary mb-1">Also on nixamp</h3>
+      <p className="text-xs text-text-muted mb-3">
+        {room
+          ? 'This party is a nixamp room. The film plays here; the room is open in every nixamp client.'
+          : 'Put this party on nixamp and it becomes a room people can join from the nixamp app, a terminal or a TV.'}
+      </p>
+
+      {room ? (
+        <div className="space-y-2">
+          <a
+            href={room.nixampUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block text-sm text-accent-primary break-all hover:underline"
+          >
+            {room.nixampUrl}
+          </a>
+          <div className="flex gap-2">
+            <button
+              onClick={copy}
+              className="px-3 py-1.5 rounded-sm bg-bg-tertiary text-text-primary text-sm hover:bg-bg-tertiary/80 transition-colors"
+            >
+              {copied ? 'Copied' : 'Copy room link'}
+            </button>
+            {isHost && positionSeconds ? (
+              <button
+                onClick={() => void sync()}
+                className="px-3 py-1.5 rounded-sm bg-accent-primary text-white text-sm hover:bg-accent-primary/90 transition-colors"
+              >
+                Sync nixamp
+              </button>
+            ) : null}
+          </div>
+        </div>
+      ) : (
+        <button
+          onClick={() => void bridge()}
+          disabled={busy}
+          className={cn(
+            'px-4 py-2 rounded-sm bg-accent-primary text-white text-sm',
+            'hover:bg-accent-primary/90 transition-colors',
+            busy && 'opacity-50 cursor-not-allowed'
+          )}
+        >
+          {busy ? 'Asking nixamp…' : 'Put this party on nixamp'}
+        </button>
+      )}
+
+      {error ? (
+        <p className="mt-2 text-xs text-red-500">
+          {error}
+          {connectAt ? (
+            <>
+              {' '}
+              <a href={connectAt} className="underline">
+                Connect nixamp
+              </a>
+            </>
+          ) : null}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/nixamp/accounts.ts
+++ b/src/lib/nixamp/accounts.ts
@@ -1,0 +1,187 @@
+/**
+ * The nixamp connection a bittorrented user holds, and keeping it alive.
+ *
+ * Server-side only: the service-role client, which bypasses RLS, is what the
+ * OAuth callback writes the row with.
+ *
+ * The one thing worth reading carefully is `usableAccessToken`. nixamp rotates
+ * refresh tokens, so refreshing is a write, not a read: the new refresh token
+ * MUST replace the old one, and if it does not, the next refresh presents a
+ * retired token and nixamp withdraws every token in the family -- which looks,
+ * from here, like the connection spontaneously dying. The write therefore
+ * happens before the new access token is handed to anybody.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createServerClient } from '@/lib/supabase';
+import { getNixampOAuthConfig, type NixampOAuthConfig } from './config';
+import { computeExpiresAt, discover, refreshTokens, revokeToken, type NixampMetadata } from './oauth';
+
+/** bt_nixamp_accounts is newer than the generated types, so the untyped client. */
+function sb(): SupabaseClient {
+  return createServerClient() as unknown as SupabaseClient;
+}
+
+export interface NixampAccount {
+  id: string;
+  userId: string;
+  nixampSub: string;
+  nixampSite: string;
+  handle: string;
+  email: string;
+  accessToken: string;
+  refreshToken: string;
+  tokenExpiresAt: Date;
+  scopes: string[];
+}
+
+interface Row {
+  id: string;
+  user_id: string;
+  nixamp_sub: string;
+  nixamp_site: string;
+  handle: string | null;
+  email: string | null;
+  access_token: string;
+  refresh_token: string | null;
+  token_expires_at: string;
+  scopes: string[] | null;
+}
+
+function fromRow(row: Row): NixampAccount {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    nixampSub: row.nixamp_sub,
+    nixampSite: row.nixamp_site,
+    handle: row.handle ?? '',
+    email: row.email ?? '',
+    accessToken: row.access_token,
+    refreshToken: row.refresh_token ?? '',
+    tokenExpiresAt: new Date(row.token_expires_at),
+    scopes: row.scopes ?? [],
+  };
+}
+
+export interface UpsertInput {
+  userId: string;
+  nixampSub: string;
+  nixampSite: string;
+  handle?: string;
+  email?: string;
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn: number;
+  scopes: string[];
+}
+
+/** Write the grant. Re-connecting the same nixamp account replaces its tokens. */
+export async function upsertNixampAccount(input: UpsertInput): Promise<NixampAccount> {
+  const { data, error } = await sb()
+    .from('bt_nixamp_accounts')
+    .upsert(
+      {
+        user_id: input.userId,
+        nixamp_sub: input.nixampSub,
+        nixamp_site: input.nixampSite,
+        handle: input.handle ?? null,
+        email: input.email ?? null,
+        access_token: input.accessToken,
+        refresh_token: input.refreshToken ?? null,
+        token_expires_at: computeExpiresAt(input.expiresIn).toISOString(),
+        scopes: input.scopes,
+      },
+      { onConflict: 'user_id,nixamp_sub' }
+    )
+    .select()
+    .single();
+  if (error) throw new Error(`Could not save the nixamp connection: ${error.message}`);
+  return fromRow(data as Row);
+}
+
+/** The connection this person has, or null. */
+export async function getNixampAccount(userId: string): Promise<NixampAccount | null> {
+  const { data, error } = await sb()
+    .from('bt_nixamp_accounts')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error || !data) return null;
+  return fromRow(data as Row);
+}
+
+/** Forget it here, and hand the tokens back to nixamp so they stop working there too. */
+export async function disconnectNixampAccount(userId: string, fetcher: typeof fetch = fetch): Promise<boolean> {
+  const account = await getNixampAccount(userId);
+  if (!account) return false;
+  try {
+    const config = { ...getNixampOAuthConfig(), site: account.nixampSite };
+    const metadata = await discover(config, fetcher);
+    // The refresh token first: revoking it takes the whole family with it,
+    // which is the point. The access token is belt and braces for a grant
+    // that never had a refresh token to revoke.
+    if (account.refreshToken) await revokeToken(config, metadata, account.refreshToken, fetcher);
+    else await revokeToken(config, metadata, account.accessToken, fetcher);
+  } catch {
+    // nixamp being unreachable must not leave a row here that the person
+    // asked to be rid of. The token expires on its own within the hour.
+  }
+  const { error } = await sb().from('bt_nixamp_accounts').delete().eq('id', account.id);
+  return !error;
+}
+
+export class NixampConnectionLost extends Error {
+  constructor(message = 'the nixamp connection has ended; connect it again') {
+    super(message);
+    this.name = 'NixampConnectionLost';
+  }
+}
+
+/**
+ * An access token that is worth presenting, refreshing first if it is not.
+ *
+ * Answers the metadata too, because every caller that wants a token wants to
+ * call something with it, and discovering twice is a round trip for nothing.
+ */
+export async function usableAccessToken(
+  account: NixampAccount,
+  fetcher: typeof fetch = fetch
+): Promise<{ accessToken: string; config: NixampOAuthConfig; metadata: NixampMetadata }> {
+  const config = { ...getNixampOAuthConfig(), site: account.nixampSite };
+  const metadata = await discover(config, fetcher);
+  if (account.tokenExpiresAt.getTime() > Date.now()) {
+    return { accessToken: account.accessToken, config, metadata };
+  }
+  if (!account.refreshToken) throw new NixampConnectionLost('that nixamp connection cannot be renewed');
+
+  let next;
+  try {
+    next = await refreshTokens(config, metadata, account.refreshToken, fetcher);
+  } catch {
+    // A refusal here is final rather than transient: nixamp rotates, so the
+    // token we hold has either been used already or been withdrawn, and
+    // trying it again is what turns a recoverable state into a lost family.
+    await sb().from('bt_nixamp_accounts').delete().eq('id', account.id);
+    throw new NixampConnectionLost();
+  }
+
+  // Written before it is used. If this process died between the exchange and
+  // the write, the row would hold a retired refresh token and the next
+  // refresh would withdraw everything.
+  await sb()
+    .from('bt_nixamp_accounts')
+    .update({
+      access_token: next.access_token,
+      refresh_token: next.refresh_token ?? account.refreshToken,
+      token_expires_at: computeExpiresAt(next.expires_in).toISOString(),
+      ...(next.scope ? { scopes: next.scope.split(' ').filter(Boolean) } : {}),
+    })
+    .eq('id', account.id);
+
+  account.accessToken = next.access_token;
+  if (next.refresh_token) account.refreshToken = next.refresh_token;
+  account.tokenExpiresAt = computeExpiresAt(next.expires_in);
+  return { accessToken: next.access_token, config, metadata };
+}

--- a/src/lib/nixamp/config.ts
+++ b/src/lib/nixamp/config.ts
@@ -1,0 +1,97 @@
+/**
+ * nixamp.com OAuth 2.1 configuration.
+ *
+ * nixamp is the authorization server and bittorrented.com is the client: nixamp
+ * keeps the accounts, the revocable tokens and the handles, and we keep the
+ * films. A watch party here becomes a room there, under the same person.
+ *
+ * Env vars, all optional except in production:
+ * - NIXAMP_SITE                  default https://nixamp.com
+ * - NIXAMP_CLIENT_ID             default `bittorrented`, which nixamp ships knowing
+ * - NIXAMP_CLIENT_SECRET         only for a confidential registration; PKCE covers us without one
+ * - NIXAMP_OAUTH_REDIRECT_URI    default <app url>/api/v1/nixamp/oauth/callback
+ *
+ * Read inside a function, never into an exported module-level const: Next
+ * statically replaces `process.env.X` at build time, so a secret captured at
+ * the top of a module compiles in as whatever it was during the build.
+ */
+
+/** Where nixamp lives. */
+export const NIXAMP_DEFAULT_SITE = 'https://nixamp.com';
+
+/** The client id nixamp registers for bittorrented.com out of the box. */
+export const NIXAMP_DEFAULT_CLIENT_ID = 'bittorrented';
+
+/**
+ * What we ask for, and why.
+ *
+ * `profile` is the handle, which is what a party shows other people --
+ * never the account email, which on nixamp is a credential rather than a
+ * name. `parties` is the whole point. `offline_access` keeps the connection
+ * alive across the hour an access token lives, so somebody who connected on
+ * Monday can still host on Friday without approving again.
+ */
+export const NIXAMP_SCOPES = ['profile', 'parties', 'offline_access'] as const;
+
+/** Cookie holding the PKCE verifier and CSRF state during the round trip. */
+export const NIXAMP_OAUTH_STATE_COOKIE = 'nixamp_oauth';
+
+/** How long that cookie is worth anything. A consent screen is not a long read. */
+export const NIXAMP_OAUTH_STATE_MAX_AGE_SECONDS = 10 * 60;
+
+export interface NixampOAuthConfig {
+  /** https://nixamp.com, with no trailing slash. */
+  site: string;
+  clientId: string;
+  /** Empty for a public client, which is what PKCE makes possible. */
+  clientSecret: string;
+  redirectUri: string;
+}
+
+function trimSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+/** Our own public origin, however this deployment spells it. */
+export function getAppOrigin(fallback = ''): string {
+  const configured =
+    process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL || process.env.NEXT_PUBLIC_SITE_URL || '';
+  return trimSlash(configured || fallback);
+}
+
+/**
+ * The configuration, or a thrown error naming exactly what is missing.
+ *
+ * `fallbackOrigin` is the request's own origin, used only to build a default
+ * redirect URI in development. In production the redirect URI has to match
+ * what nixamp has registered, byte for byte, so it is worth setting.
+ */
+export function getNixampOAuthConfig(fallbackOrigin = ''): NixampOAuthConfig {
+  const site = trimSlash(process.env.NIXAMP_SITE || NIXAMP_DEFAULT_SITE);
+  const clientId = process.env.NIXAMP_CLIENT_ID || NIXAMP_DEFAULT_CLIENT_ID;
+  const origin = getAppOrigin(fallbackOrigin);
+  const redirectUri = process.env.NIXAMP_OAUTH_REDIRECT_URI || (origin ? `${origin}/api/v1/nixamp/oauth/callback` : '');
+
+  if (!redirectUri) {
+    throw new Error(
+      'Cannot build the nixamp OAuth redirect URI. Set NIXAMP_OAUTH_REDIRECT_URI, or NEXT_PUBLIC_APP_URL.'
+    );
+  }
+
+  return {
+    site,
+    clientId,
+    clientSecret: process.env.NIXAMP_CLIENT_SECRET || '',
+    redirectUri,
+  };
+}
+
+/** Is a nixamp connection configured enough to offer at all? */
+export function isNixampConfigured(fallbackOrigin = ''): boolean {
+  try {
+    getNixampOAuthConfig(fallbackOrigin);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/nixamp/index.ts
+++ b/src/lib/nixamp/index.ts
@@ -1,0 +1,55 @@
+/**
+ * nixamp.com, from bittorrented.com's side.
+ *
+ * nixamp is the OAuth 2.1 authorization server; we are the client. A watch
+ * party here becomes a room there, so the same party is joinable from every
+ * nixamp surface without any of them learning anything about torrents.
+ */
+
+export {
+  NIXAMP_DEFAULT_CLIENT_ID,
+  NIXAMP_DEFAULT_SITE,
+  NIXAMP_OAUTH_STATE_COOKIE,
+  NIXAMP_OAUTH_STATE_MAX_AGE_SECONDS,
+  NIXAMP_SCOPES,
+  getAppOrigin,
+  getNixampOAuthConfig,
+  isNixampConfigured,
+  type NixampOAuthConfig,
+} from './config';
+
+export {
+  NixampOAuthError,
+  buildAuthUrl,
+  codeChallenge,
+  computeExpiresAt,
+  discover,
+  exchangeCodeForTokens,
+  fetchUserInfo,
+  generateCodeVerifier,
+  generateState,
+  refreshTokens,
+  revokeToken,
+  type NixampMetadata,
+  type NixampTokenResponse,
+  type NixampUserInfo,
+} from './oauth';
+
+export {
+  NixampConnectionLost,
+  disconnectNixampAccount,
+  getNixampAccount,
+  upsertNixampAccount,
+  usableAccessToken,
+  type NixampAccount,
+} from './accounts';
+
+export {
+  NixampNotConnected,
+  bridgeParty,
+  endBridgedParty,
+  getBridgedRoom,
+  pushPlayback,
+  watchPartyUrl,
+  type BridgedRoom,
+} from './rooms';

--- a/src/lib/nixamp/oauth.test.ts
+++ b/src/lib/nixamp/oauth.test.ts
@@ -1,0 +1,212 @@
+/**
+ * The OAuth 2.1 client half: PKCE, discovery, the exchange and rotation.
+ *
+ * Nothing here touches Supabase — the storage side is exercised through the
+ * route tests. What is under test is the wire: that a challenge really is the
+ * S256 of the verifier, that discovery refuses a document claiming to be
+ * somebody else, and that a rotation failure is reported as such rather than
+ * swallowed.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  NixampOAuthError,
+  buildAuthUrl,
+  codeChallenge,
+  computeExpiresAt,
+  discover,
+  exchangeCodeForTokens,
+  fetchUserInfo,
+  generateCodeVerifier,
+  generateState,
+  refreshTokens,
+  type NixampMetadata,
+} from './oauth';
+import type { NixampOAuthConfig } from './config';
+
+const config: NixampOAuthConfig = {
+  site: 'https://nixamp.test',
+  clientId: 'bittorrented',
+  clientSecret: '',
+  redirectUri: 'https://bittorrented.test/api/v1/nixamp/oauth/callback',
+};
+
+const metadata: NixampMetadata = {
+  issuer: 'https://nixamp.test',
+  authorization_endpoint: 'https://nixamp.test/api/v1/oauth/authorize',
+  token_endpoint: 'https://nixamp.test/api/v1/oauth/token',
+  revocation_endpoint: 'https://nixamp.test/api/v1/oauth/revoke',
+  userinfo_endpoint: 'https://nixamp.test/api/v1/oauth/userinfo',
+};
+
+function answering(body: unknown, status = 200): typeof fetch {
+  return vi.fn(async () =>
+    new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+  ) as unknown as typeof fetch;
+}
+
+describe('PKCE', () => {
+  it('makes a verifier of the length and alphabet RFC 7636 allows', () => {
+    for (let i = 0; i < 10; i += 1) {
+      const verifier = generateCodeVerifier();
+      expect(verifier).toMatch(/^[A-Za-z0-9\-._~]{43,128}$/);
+    }
+  });
+
+  it('makes a challenge that is the base64url SHA-256 of the verifier', async () => {
+    const challenge = await codeChallenge('a'.repeat(43));
+    // The known value, cross-checked against Node's crypto -- which is what
+    // nixamp's own AuthorizationServer uses. Nothing about this may drift:
+    // nixamp computes the same digest and compares the two, so a WebCrypto
+    // implementation that disagreed here would fail every exchange.
+    expect(challenge).toBe('ZtNPunH49FD35FWYhT5Tv8I7vRKQJ8uxMaL0_9eHjNA');
+    expect(challenge).toMatch(/^[A-Za-z0-9\-_]{43}$/);
+    // A different verifier is a different challenge.
+    expect(await codeChallenge('b'.repeat(43))).not.toBe(challenge);
+  });
+
+  it('makes a state that is separate from the verifier', () => {
+    expect(generateState()).not.toBe(generateState());
+  });
+});
+
+describe('the authorization URL', () => {
+  it('carries PKCE, the exact redirect URI, and only the scopes we ask for', async () => {
+    const url = new URL(buildAuthUrl(config, metadata, 'st4te', await codeChallenge('c'.repeat(43))));
+    expect(url.origin + url.pathname).toBe('https://nixamp.test/api/v1/oauth/authorize');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('code_challenge')).toHaveLength(43);
+    expect(url.searchParams.get('redirect_uri')).toBe(config.redirectUri);
+    expect(url.searchParams.get('scope')).toBe('profile parties offline_access');
+    expect(url.searchParams.get('state')).toBe('st4te');
+  });
+});
+
+describe('discovery', () => {
+  it('takes the endpoints from the well-known document', async () => {
+    const fetcher = answering({
+      issuer: 'https://nixamp.test',
+      authorization_endpoint: 'https://nixamp.test/elsewhere/authorize',
+      token_endpoint: 'https://nixamp.test/elsewhere/token',
+    });
+    const found = await discover(config, fetcher);
+    expect(found.authorization_endpoint).toBe('https://nixamp.test/elsewhere/authorize');
+    expect(found.token_endpoint).toBe('https://nixamp.test/elsewhere/token');
+  });
+
+  it('refuses a document that claims to be a different issuer', async () => {
+    // Following this would point our token exchange, with our code, at
+    // somebody else's server.
+    const fetcher = answering({
+      issuer: 'https://evil.test',
+      token_endpoint: 'https://evil.test/token',
+    });
+    const found = await discover(config, fetcher);
+    expect(found.token_endpoint).toBe('https://nixamp.test/api/v1/oauth/token');
+  });
+
+  it('falls back to the spelled-out endpoints when nixamp cannot be reached', async () => {
+    const fetcher = vi.fn(async () => {
+      throw new Error('offline');
+    }) as unknown as typeof fetch;
+    const found = await discover(config, fetcher);
+    expect(found.authorization_endpoint).toBe('https://nixamp.test/api/v1/oauth/authorize');
+  });
+});
+
+describe('the token endpoint', () => {
+  it('sends the verifier and the exact redirect URI with the code', async () => {
+    const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = new URLSearchParams(String(init?.body));
+      expect(body.get('grant_type')).toBe('authorization_code');
+      expect(body.get('code_verifier')).toBe('v'.repeat(43));
+      expect(body.get('redirect_uri')).toBe(config.redirectUri);
+      expect(body.get('client_id')).toBe('bittorrented');
+      // A public client sends no secret, and PKCE is what replaces it.
+      expect(body.get('client_secret')).toBeNull();
+      return new Response(
+        JSON.stringify({ access_token: 'nxa_1_a', token_type: 'Bearer', expires_in: 3600, refresh_token: 'nxr_1_b', scope: 'profile parties offline_access' }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }) as unknown as typeof fetch;
+
+    const tokens = await exchangeCodeForTokens(config, metadata, 'the-code', 'v'.repeat(43), fetcher);
+    expect(tokens.access_token).toBe('nxa_1_a');
+    expect(tokens.refresh_token).toBe('nxr_1_b');
+  });
+
+  it('authenticates with basic auth only when there is a secret to send', async () => {
+    const seen: (string | undefined)[] = [];
+    const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+      seen.push((init?.headers as Record<string, string>)?.Authorization);
+      return new Response(JSON.stringify({ access_token: 'nxa_x_y', expires_in: 60, scope: '' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    await exchangeCodeForTokens(config, metadata, 'c', 'v'.repeat(43), fetcher);
+    await exchangeCodeForTokens({ ...config, clientSecret: 'sh' }, metadata, 'c', 'v'.repeat(43), fetcher);
+    expect(seen[0]).toBeUndefined();
+    expect(seen[1]).toMatch(/^Basic /);
+  });
+
+  it('reports nixamp’s own refusal rather than a generic failure', async () => {
+    const fetcher = answering({ error: 'invalid_grant', error_description: 'that code was already used' }, 400);
+    await expect(exchangeCodeForTokens(config, metadata, 'c', 'v'.repeat(43), fetcher)).rejects.toThrow(
+      /that code was already used/
+    );
+    await expect(exchangeCodeForTokens(config, metadata, 'c', 'v'.repeat(43), fetcher)).rejects.toBeInstanceOf(
+      NixampOAuthError
+    );
+  });
+
+  it('refuses a 200 that carries no access token', async () => {
+    const fetcher = answering({ token_type: 'Bearer' });
+    await expect(exchangeCodeForTokens(config, metadata, 'c', 'v'.repeat(43), fetcher)).rejects.toThrow();
+  });
+});
+
+describe('refresh rotation', () => {
+  it('always answers the new refresh token, which the caller must store', async () => {
+    const fetcher = answering({
+      access_token: 'nxa_2_a',
+      refresh_token: 'nxr_2_b',
+      expires_in: 3600,
+      scope: 'profile parties offline_access',
+    });
+    const next = await refreshTokens(config, metadata, 'nxr_1_b', fetcher);
+    expect(next.refresh_token).toBe('nxr_2_b');
+    expect(next.access_token).toBe('nxa_2_a');
+  });
+
+  it('throws when the token was already rotated, so the caller can stop trying', async () => {
+    const fetcher = answering({ error: 'invalid_grant', error_description: 'that refresh token was already used' }, 400);
+    await expect(refreshTokens(config, metadata, 'nxr_1_b', fetcher)).rejects.toThrow(/already used/);
+  });
+});
+
+describe('userinfo', () => {
+  it('takes the handle as the public name and leaves the address alone', async () => {
+    const fetcher = answering({ sub: 'user-1', handle: 'chovy', scope: 'profile parties' });
+    const who = await fetchUserInfo(metadata, 'nxa_1_a', fetcher);
+    expect(who.sub).toBe('user-1');
+    expect(who.handle).toBe('chovy');
+    // No email scope was granted, so no address comes back to be stored.
+    expect(who.email).toBeUndefined();
+  });
+
+  it('refuses an answer that does not say who it is', async () => {
+    await expect(fetchUserInfo(metadata, 'nxa_1_a', answering({ handle: 'chovy' }))).rejects.toThrow(/who this is/);
+  });
+});
+
+describe('expiry', () => {
+  it('retires a token a minute before nixamp would, so a call in flight is not refused', () => {
+    const at = computeExpiresAt(3600, 0);
+    expect(at.getTime()).toBe(3540 * 1000);
+    // Never in the past, however small the lifetime nixamp reported.
+    expect(computeExpiresAt(10, 0).getTime()).toBe(0);
+  });
+});

--- a/src/lib/nixamp/oauth.ts
+++ b/src/lib/nixamp/oauth.ts
@@ -1,0 +1,249 @@
+/**
+ * The OAuth 2.1 client half: PKCE, the code exchange, and refresh rotation.
+ *
+ * Plain fetch, no SDK, in the shape `src/lib/youtube/oauth.ts` already uses.
+ * What is new here is PKCE, which nothing else in this repo does, and which
+ * OAuth 2.1 requires of every client -- including a confidential one. The
+ * verifier never leaves this origin: it goes into an httpOnly cookie on the
+ * way out and comes back out of it to be spent once at the token endpoint.
+ *
+ * The other 2.1 difference worth knowing when reading this: nixamp ROTATES
+ * refresh tokens. Every refresh answers a new one and retires the old, and
+ * presenting a retired one withdraws the whole family. So `refreshTokens`
+ * always writes the new refresh token back, and a failure means the
+ * connection is gone rather than that it should be retried.
+ */
+
+import type { NixampOAuthConfig } from './config';
+import { NIXAMP_SCOPES } from './config';
+
+export interface NixampTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token?: string;
+  scope: string;
+}
+
+export interface NixampUserInfo {
+  sub: string;
+  client_id?: string;
+  scope?: string;
+  handle?: string;
+  preferred_username?: string;
+  email?: string;
+  email_verified?: boolean;
+}
+
+/** RFC 8414: where a client is meant to look for the endpoints. */
+export interface NixampMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  revocation_endpoint?: string;
+  userinfo_endpoint?: string;
+  code_challenge_methods_supported?: string[];
+  grant_types_supported?: string[];
+}
+
+function base64url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** A PKCE verifier: 43 to 128 unreserved characters (RFC 7636 §4.1). */
+export function generateCodeVerifier(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return base64url(bytes);
+}
+
+/** S256, which is the only method OAuth 2.1 allows. */
+export async function codeChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  return base64url(new Uint8Array(digest));
+}
+
+/** An opaque CSRF state. Separate from the verifier on purpose: different jobs. */
+export function generateState(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return base64url(bytes);
+}
+
+/** The endpoints, straight from the well-known document, with the spelled-out fallback. */
+export async function discover(config: NixampOAuthConfig, fetcher: typeof fetch = fetch): Promise<NixampMetadata> {
+  const fallback: NixampMetadata = {
+    issuer: config.site,
+    authorization_endpoint: `${config.site}/api/v1/oauth/authorize`,
+    token_endpoint: `${config.site}/api/v1/oauth/token`,
+    revocation_endpoint: `${config.site}/api/v1/oauth/revoke`,
+    userinfo_endpoint: `${config.site}/api/v1/oauth/userinfo`,
+  };
+  try {
+    const res = await fetcher(`${config.site}/.well-known/oauth-authorization-server`, {
+      headers: { accept: 'application/json' },
+    });
+    if (!res.ok) return fallback;
+    const body = (await res.json()) as Partial<NixampMetadata>;
+    // An issuer that is not the site we asked is a document we must not
+    // follow: it would point our token exchange at somebody else's server.
+    if (body.issuer !== config.site) return fallback;
+    return {
+      issuer: body.issuer,
+      authorization_endpoint: body.authorization_endpoint ?? fallback.authorization_endpoint,
+      token_endpoint: body.token_endpoint ?? fallback.token_endpoint,
+      revocation_endpoint: body.revocation_endpoint ?? fallback.revocation_endpoint,
+      userinfo_endpoint: body.userinfo_endpoint ?? fallback.userinfo_endpoint,
+      ...(body.code_challenge_methods_supported
+        ? { code_challenge_methods_supported: body.code_challenge_methods_supported }
+        : {}),
+      ...(body.grant_types_supported ? { grant_types_supported: body.grant_types_supported } : {}),
+    };
+  } catch {
+    // nixamp being unreachable is not a reason to be unable to build a URL.
+    return fallback;
+  }
+}
+
+/** Where to send the browser. */
+export function buildAuthUrl(
+  config: NixampOAuthConfig,
+  metadata: NixampMetadata,
+  state: string,
+  challenge: string
+): string {
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+    scope: NIXAMP_SCOPES.join(' '),
+    state,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+  });
+  return `${metadata.authorization_endpoint}?${params.toString()}`;
+}
+
+async function postForm(
+  url: string,
+  body: URLSearchParams,
+  config: NixampOAuthConfig,
+  fetcher: typeof fetch
+): Promise<Response> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/x-www-form-urlencoded' };
+  if (config.clientSecret) {
+    // A registration that has a secret authenticates with it; a public one
+    // presents only its id, and PKCE is what makes that safe.
+    headers.Authorization = `Basic ${btoa(
+      `${encodeURIComponent(config.clientId)}:${encodeURIComponent(config.clientSecret)}`
+    )}`;
+  }
+  return fetcher(url, { method: 'POST', headers, body });
+}
+
+export class NixampOAuthError extends Error {
+  constructor(
+    message: string,
+    readonly code: string
+  ) {
+    super(message);
+    this.name = 'NixampOAuthError';
+  }
+}
+
+async function readTokens(res: Response): Promise<NixampTokenResponse> {
+  const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok || typeof body.access_token !== 'string') {
+    const code = typeof body.error === 'string' ? body.error : `http_${res.status}`;
+    const description = typeof body.error_description === 'string' ? body.error_description : 'nixamp refused the exchange';
+    throw new NixampOAuthError(description, code);
+  }
+  return {
+    access_token: body.access_token,
+    token_type: typeof body.token_type === 'string' ? body.token_type : 'Bearer',
+    expires_in: typeof body.expires_in === 'number' ? body.expires_in : 3600,
+    ...(typeof body.refresh_token === 'string' ? { refresh_token: body.refresh_token } : {}),
+    scope: typeof body.scope === 'string' ? body.scope : '',
+  };
+}
+
+/** Spend the code, with the verifier that proves we are who started this. */
+export async function exchangeCodeForTokens(
+  config: NixampOAuthConfig,
+  metadata: NixampMetadata,
+  code: string,
+  codeVerifier: string,
+  fetcher: typeof fetch = fetch
+): Promise<NixampTokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+    code,
+    code_verifier: codeVerifier,
+  });
+  return readTokens(await postForm(metadata.token_endpoint, body, config, fetcher));
+}
+
+/**
+ * A new pair. The answer ALWAYS carries a new refresh token, and storing it
+ * is not optional: nixamp retires the one just used, and presenting a retired
+ * token again withdraws every token in the family.
+ */
+export async function refreshTokens(
+  config: NixampOAuthConfig,
+  metadata: NixampMetadata,
+  refreshToken: string,
+  fetcher: typeof fetch = fetch
+): Promise<NixampTokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: config.clientId,
+    refresh_token: refreshToken,
+  });
+  return readTokens(await postForm(metadata.token_endpoint, body, config, fetcher));
+}
+
+/** Hand a token back, when somebody disconnects from this side. */
+export async function revokeToken(
+  config: NixampOAuthConfig,
+  metadata: NixampMetadata,
+  token: string,
+  fetcher: typeof fetch = fetch
+): Promise<void> {
+  if (!metadata.revocation_endpoint) return;
+  const body = new URLSearchParams({ client_id: config.clientId, token });
+  await postForm(metadata.revocation_endpoint, body, config, fetcher).catch(() => undefined);
+}
+
+/** Who the token belongs to on nixamp. The handle is the public name; the id is the link. */
+export async function fetchUserInfo(
+  metadata: NixampMetadata,
+  accessToken: string,
+  fetcher: typeof fetch = fetch
+): Promise<NixampUserInfo> {
+  const res = await fetcher(metadata.userinfo_endpoint ?? `${metadata.issuer}/api/v1/oauth/userinfo`, {
+    headers: { Authorization: `Bearer ${accessToken}`, accept: 'application/json' },
+  });
+  if (!res.ok) throw new NixampOAuthError(`nixamp userinfo failed (${res.status})`, 'userinfo_failed');
+  const body = (await res.json()) as Record<string, unknown>;
+  if (typeof body.sub !== 'string' || !body.sub) {
+    throw new NixampOAuthError('nixamp did not say who this is', 'no_subject');
+  }
+  return {
+    sub: body.sub,
+    ...(typeof body.client_id === 'string' ? { client_id: body.client_id } : {}),
+    ...(typeof body.scope === 'string' ? { scope: body.scope } : {}),
+    ...(typeof body.handle === 'string' ? { handle: body.handle } : {}),
+    ...(typeof body.preferred_username === 'string' ? { preferred_username: body.preferred_username } : {}),
+    ...(typeof body.email === 'string' ? { email: body.email } : {}),
+    ...(typeof body.email_verified === 'boolean' ? { email_verified: body.email_verified } : {}),
+  };
+}
+
+/** When an access token stops being worth presenting, with a minute of slack. */
+export function computeExpiresAt(expiresIn: number, now = Date.now()): Date {
+  return new Date(now + Math.max(0, expiresIn - 60) * 1000);
+}

--- a/src/lib/nixamp/rooms.ts
+++ b/src/lib/nixamp/rooms.ts
@@ -1,0 +1,197 @@
+/**
+ * A watch party here, as a room on nixamp.
+ *
+ * The film never leaves bittorrented.com: we have the torrent, the rights and
+ * the bandwidth, and nixamp has none of those. What crosses over is the room
+ * -- who is in it, the chat, and the second everybody is supposed to be at --
+ * because that is the part every nixamp client already knows how to open: the
+ * browser, the terminal, the desktop app, the television and an agent over MCP.
+ *
+ * Bridging is idempotent on both sides. We call it whenever the host opens
+ * the party page, and nixamp answers the same room rather than making a
+ * second one; the row we keep is only so this process does not have to ask
+ * nixamp before it can tell a member where the room is.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createServerClient } from '@/lib/supabase';
+import { getAppOrigin } from './config';
+import { getNixampAccount, usableAccessToken, NixampConnectionLost } from './accounts';
+
+function sb(): SupabaseClient {
+  return createServerClient() as unknown as SupabaseClient;
+}
+
+export interface BridgedRoom {
+  partyCode: string;
+  nixampSite: string;
+  eventId: string;
+  roomId: string;
+  slug: string;
+  /** https://nixamp.com/live/<slug> — the room, joinable from any nixamp client. */
+  nixampUrl: string;
+}
+
+interface RoomRow {
+  party_code: string;
+  nixamp_site: string;
+  nixamp_event_id: string;
+  nixamp_room_id: string;
+  nixamp_slug: string;
+  nixamp_url: string;
+}
+
+function fromRow(row: RoomRow): BridgedRoom {
+  return {
+    partyCode: row.party_code,
+    nixampSite: row.nixamp_site,
+    eventId: row.nixamp_event_id,
+    roomId: row.nixamp_room_id,
+    slug: row.nixamp_slug,
+    nixampUrl: row.nixamp_url,
+  };
+}
+
+/** Where a party can be watched here, which is what nixamp shows its clients. */
+export function watchPartyUrl(partyCode: string, origin = ''): string {
+  const base = getAppOrigin(origin) || 'https://bittorrented.com';
+  return `${base}/watch-party?code=${encodeURIComponent(partyCode)}`;
+}
+
+/** The room a party already has, without asking nixamp. */
+export async function getBridgedRoom(partyCode: string): Promise<BridgedRoom | null> {
+  const { data, error } = await sb()
+    .from('bt_watch_party_rooms')
+    .select('*')
+    .eq('party_code', partyCode.toUpperCase())
+    .maybeSingle();
+  if (error || !data) return null;
+  return fromRow(data as RoomRow);
+}
+
+interface NixampPartyAnswer {
+  party?: { roomId?: string; slug?: string; partyCode?: string; positionNow?: number; playing?: boolean };
+  event?: { id?: string; title?: string; status?: string };
+  links?: { nixampUrl?: string; roomUrl?: string };
+  error?: string;
+}
+
+export class NixampNotConnected extends Error {
+  constructor() {
+    super('connect your nixamp account first');
+    this.name = 'NixampNotConnected';
+  }
+}
+
+export interface BridgeInput {
+  userId: string;
+  partyCode: string;
+  title?: string;
+  mediaTitle?: string;
+  /** This deployment's own origin, when it is not the configured one. */
+  origin?: string;
+}
+
+/**
+ * Put a party on nixamp as a room, under the host's own nixamp account.
+ *
+ * Deliberately the HOST's account and not a service credential: the room
+ * belongs to a person over there, appears in their events, and is theirs to
+ * end. A service account would make every party on nixamp belong to
+ * "bittorrented", which is nobody.
+ */
+export async function bridgeParty(input: BridgeInput, fetcher: typeof fetch = fetch): Promise<BridgedRoom> {
+  const account = await getNixampAccount(input.userId);
+  if (!account) throw new NixampNotConnected();
+  const { accessToken, config } = await usableAccessToken(account, fetcher);
+
+  const res = await fetcher(`${config.site}/api/v1/watch-parties`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      partyCode: input.partyCode,
+      ...(input.title ? { title: input.title } : {}),
+      ...(input.mediaTitle ? { mediaTitle: input.mediaTitle } : {}),
+      partyUrl: watchPartyUrl(input.partyCode, input.origin),
+    }),
+  });
+  const body = (await res.json().catch(() => ({}))) as NixampPartyAnswer;
+  if (!res.ok || !body.party?.roomId || !body.event?.id) {
+    throw new Error(body.error ?? `nixamp would not bridge that party (${res.status})`);
+  }
+
+  const room: BridgedRoom = {
+    partyCode: input.partyCode.toUpperCase(),
+    nixampSite: config.site,
+    eventId: body.event.id,
+    roomId: body.party.roomId,
+    slug: body.party.slug ?? '',
+    nixampUrl: body.links?.nixampUrl ?? `${config.site}/live/${body.party.slug ?? body.event.id}`,
+  };
+
+  await sb().from('bt_watch_party_rooms').upsert(
+    {
+      party_code: room.partyCode,
+      host_user_id: input.userId,
+      nixamp_site: room.nixampSite,
+      nixamp_event_id: room.eventId,
+      nixamp_room_id: room.roomId,
+      nixamp_slug: room.slug,
+      nixamp_url: room.nixampUrl,
+    },
+    { onConflict: 'party_code' }
+  );
+
+  return room;
+}
+
+/**
+ * Tell nixamp where playback is, so somebody joining from a nixamp client
+ * lands on the same second as everybody in the browser here.
+ *
+ * Best effort by design: a watch party whose players are in sync locally must
+ * not stop working because nixamp is slow. It answers whether it landed.
+ */
+export async function pushPlayback(
+  input: { userId: string; partyCode: string; positionSeconds: number; playing: boolean; mediaTitle?: string },
+  fetcher: typeof fetch = fetch
+): Promise<boolean> {
+  const account = await getNixampAccount(input.userId);
+  if (!account) return false;
+  try {
+    const { accessToken, config } = await usableAccessToken(account, fetcher);
+    const res = await fetcher(
+      `${config.site}/api/v1/watch-parties/${encodeURIComponent(input.partyCode)}/playback`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          positionSeconds: input.positionSeconds,
+          playing: input.playing,
+          ...(input.mediaTitle ? { mediaTitle: input.mediaTitle } : {}),
+        }),
+      }
+    );
+    return res.ok;
+  } catch (error) {
+    if (error instanceof NixampConnectionLost) return false;
+    return false;
+  }
+}
+
+/** End the room when the party ends. Same best-effort reasoning. */
+export async function endBridgedParty(userId: string, partyCode: string, fetcher: typeof fetch = fetch): Promise<boolean> {
+  const account = await getNixampAccount(userId);
+  if (!account) return false;
+  try {
+    const { accessToken, config } = await usableAccessToken(account, fetcher);
+    const res = await fetcher(`${config.site}/api/v1/watch-parties/${encodeURIComponent(partyCode)}/end`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (res.ok) await sb().from('bt_watch_party_rooms').delete().eq('party_code', partyCode.toUpperCase());
+    return res.ok;
+  } catch {
+    return false;
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -391,6 +391,10 @@ const PROFILE_EXEMPT_PATHS = [
   '/pricing',
   '/api/auth',
   '/api/profiles',
+  // The nixamp OAuth round trip. Bouncing somebody to /select-profile in the
+  // middle of a consent flow loses the code, the state and the verifier, and
+  // lands them back here with nothing connected and no way to tell why.
+  '/api/v1/nixamp',
   '/_next',
   '/favicon',
   '/manifest',

--- a/supabase/migrations/20260911180000_nixamp_accounts.sql
+++ b/supabase/migrations/20260911180000_nixamp_accounts.sql
@@ -1,0 +1,111 @@
+-- nixamp integration: the nixamp account a bittorrented user has connected.
+--
+-- nixamp.com is the OAuth 2.1 authorization server and we are the client, so
+-- what is stored here is a grant rather than a credential: the nixamp user id
+-- (the `sub`), the public handle to show other people, and the token pair.
+--
+-- One row per (user_id, nixamp_sub), matching bt_youtube_accounts. A person
+-- may connect only one nixamp account in practice, but keying it this way
+-- means re-connecting a DIFFERENT nixamp account adds a row rather than
+-- silently overwriting the first one's tokens with the second one's.
+--
+-- The handle, not the email, is what any surface shows. On nixamp the account
+-- address is the OAuth linking key and is treated as a credential; the handle
+-- is the name that is safe in a room full of strangers.
+
+CREATE TABLE IF NOT EXISTS bt_nixamp_accounts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  nixamp_sub TEXT NOT NULL,                 -- stable nixamp account id
+  nixamp_site TEXT NOT NULL DEFAULT 'https://nixamp.com',
+  handle TEXT,                              -- the public name, e.g. chovy
+  email TEXT,                               -- only when the email scope was granted
+  access_token TEXT NOT NULL,               -- TODO: encrypt at rest
+  -- Nullable because a grant without offline_access has none, and a row with
+  -- an empty string for "no refresh token" is a row that will be presented as
+  -- one -- which on nixamp withdraws the whole family.
+  refresh_token TEXT,                       -- TODO: encrypt at rest
+  token_expires_at TIMESTAMPTZ NOT NULL,
+  scopes TEXT[] NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (user_id, nixamp_sub)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bt_nixamp_accounts_user_id
+  ON bt_nixamp_accounts(user_id);
+
+CREATE OR REPLACE FUNCTION bt_nixamp_accounts_set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_bt_nixamp_accounts_updated_at ON bt_nixamp_accounts;
+CREATE TRIGGER trg_bt_nixamp_accounts_updated_at
+  BEFORE UPDATE ON bt_nixamp_accounts
+  FOR EACH ROW
+  EXECUTE FUNCTION bt_nixamp_accounts_set_updated_at();
+
+-- RLS: a person sees only their own connection. The server uses the service
+-- role and bypasses this, which is how the callback writes the row.
+ALTER TABLE bt_nixamp_accounts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own nixamp account"
+  ON bt_nixamp_accounts FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own nixamp account"
+  ON bt_nixamp_accounts FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own nixamp account"
+  ON bt_nixamp_accounts FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own nixamp account"
+  ON bt_nixamp_accounts FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- Which nixamp room a watch party has been bridged to.
+--
+-- The party itself still lives in the in-memory store next to the API route;
+-- what is durable is the LINK, because a room on nixamp outlives this process
+-- and re-bridging a party that already has a room would make a second room
+-- nobody is in.
+CREATE TABLE IF NOT EXISTS bt_watch_party_rooms (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  party_code TEXT NOT NULL UNIQUE,
+  host_user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  nixamp_site TEXT NOT NULL DEFAULT 'https://nixamp.com',
+  nixamp_event_id TEXT NOT NULL,
+  nixamp_room_id TEXT NOT NULL,
+  nixamp_slug TEXT NOT NULL,
+  nixamp_url TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_bt_watch_party_rooms_host
+  ON bt_watch_party_rooms(host_user_id);
+
+DROP TRIGGER IF EXISTS trg_bt_watch_party_rooms_updated_at ON bt_watch_party_rooms;
+CREATE TRIGGER trg_bt_watch_party_rooms_updated_at
+  BEFORE UPDATE ON bt_watch_party_rooms
+  FOR EACH ROW
+  EXECUTE FUNCTION bt_nixamp_accounts_set_updated_at();
+
+-- A bridged room is public knowledge: the whole point is that anybody with
+-- the party code can find the room and join it. Writing is the server's.
+ALTER TABLE bt_watch_party_rooms ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Anyone can see a bridged watch party room"
+  ON bt_watch_party_rooms FOR SELECT
+  USING (TRUE);


### PR DESCRIPTION
A watch party on bittorrented.com becomes a room on nixamp.com, joinable from every nixamp surface -- the web app, a terminal, the desktop app, a television, an agent over MCP -- while the film stays here, on the site that has the torrent and the rights.

Pairs with **profullstack/nixamp#127**, which makes nixamp the OAuth 2.1 authorization server. This is the client half.

## The direction, and why

nixamp keeps accounts, revocable tokens and public handles; we keep none of those. So nixamp is the AS, we are the client, and `src/lib/nixamp/` is a third-party-OAuth integration in the shape `src/lib/youtube/` already uses -- plain fetch, a per-module `getNixampOAuthConfig()`, env read inside a function so Next cannot inline a secret at build time.

The new part is **PKCE**, which nothing else in this repo does and which OAuth 2.1 requires of every client. The verifier and the CSRF state ride out together in one httpOnly cookie and never reach page JavaScript.

## The thing most likely to bite whoever touches this next

**nixamp rotates refresh tokens.** Refreshing is a write, not a read: nixamp retires the token just used, and presenting a retired one withdraws the whole family. So in `accounts.ts`:

- the new pair is stored **before** the access token is handed to any caller. If this process died between the exchange and the write, the row would hold a retired token and the next refresh would withdraw everything.
- a refusal **deletes the row** rather than being retried. Retrying is what turns a recoverable state into a connection that has silently died, and the caller gets `NixampConnectionLost` so the UI can say "connect it again" instead of "something went wrong".

## The bridge

`src/lib/nixamp/rooms.ts` puts the room under the **host's own nixamp account**, not a service credential. The room is a person's over there: it appears in their events and is theirs to end. A service account would make every party on nixamp belong to "bittorrented", which is nobody.

`POST /api/watch-party` now takes the signed-in user as the host when there is one. A party still needs no account -- an anonymous host gets a guest id exactly as before -- but putting one on nixamp has to be provably the host's doing, and `guest_1757...` proves nothing. The bridge endpoint checks twice: signed-in user, and host of the party as the store has it.

`GET /api/watch-party/nixamp?code=` is public, because a member handed a code needs the room link and that link is not the secret -- the room's own visibility on nixamp decides who may be in it.

## Also here

- Two tables following the `bt_youtube_accounts` shape: `bt_nixamp_accounts` and `bt_watch_party_rooms`, with RLS and the `updated_at` trigger.
- A **Connections** tab in settings (`/settings?tab=connections`), the first management UI for any connected account in this repo.
- An **"Also on nixamp"** panel in the party room. The host gets a bridge button and a Sync button, and the position goes over on its own every 15s -- somebody opening the room from a terminal an hour in should land an hour in, and asking the host to press a button for that would not happen.
- `/api/v1/nixamp` added to `PROFILE_EXEMPT_PATHS` in `src/proxy.ts`. Without it a signed-in user with no profile cookie is bounced to `/select-profile` mid-consent and loses the code, the state and the verifier.
- `.env.example` documents the four `NIXAMP_*` vars. In production none of them need setting: nixamp ships knowing `bittorrented` and its redirect URIs.

The **handle** is what is shown anywhere a person is named. On nixamp the account email is the OAuth linking key and is a credential; the handle is the name that is safe in a room full of strangers.

## Testing

`pnpm test`: **2871 pass, 5 skipped, 0 fail** (28 new). `pnpm typecheck` clean. `pnpm lint` has no warnings from any new file. `pnpm build` green, with all four new routes registering.

## Known gaps

- The watch party store is still the in-memory `Map` beside the route, so a bridged party survives a deploy on the nixamp side and not on ours. `bt_watch_party_rooms` is durable, which means the room link outlives the party -- worth persisting the party itself next, per the schema already sketched in `plans/bittorrented-expansion-plan.md`.
- There is still no SSE or realtime on the watch party, so the chat panel is as static as it was. nixamp's room has working chat, which is a reason to lean on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QuUkTrofSjQ15j79mRuy4f